### PR TITLE
fix(hooks): v0.15.2 — dist/hooks CLI bootstrap (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ---
 
+## [0.15.2] - 2026-04-20
+
+### Fixed
+
+- 세 하네스(Claude·Codex·OpenCode) 공통 hook bundle이 `export default handler`만 담아 `node dist/hooks/<name>.js` 실행 시 handler가 호출되지 않고 silent no-op으로 종료되던 critical 버그 ([#39](https://github.com/moreih29/nexus-core/issues/39)).
+  `scripts/build-hooks.ts compileHandlers()`가 각 hook별로 stdin→JSON.parse→handler invoke→stdout write 부트스트랩을 수행하는 임시 entry 파일을 emit한 뒤 `bun build`에 이 entry를 입력으로 주입하도록 변경되었습니다. `assets/hooks/*/handler.ts` 소스는 순수 라이브러리로 유지되고, `dist/hooks/<name>.js`만 CLI 진입점으로 동작합니다.
+  영향: SessionStart 시 `.nexus/state/<sid>/` 생성, `[run]`·`[plan]`·`[sync]` tag dispatch, agent-tracker 기록, SubagentStop additional_context 주입 경로가 모두 복구됩니다. OpenCode `spawnHandler` (spawn+stdin+stdout JSON) 경로도 동일 번들로 정상 동작합니다.
+
+### Migration Notes
+
+- `bun add @moreih29/nexus-core@^0.15.2` / `npm i @moreih29/nexus-core@0.15.2`로 bump. Consumer sync를 재실행하여 새 번들을 target에 복사하세요(`bun run sync`).
+- v0.15.0 / v0.15.1은 hook 경로 전체가 silent no-op이므로 **deprecate 권장**.
+
+---
+
 ## [0.15.1] - 2026-04-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Nexus ecosystem authoring layer — canonical agents/skills/hooks and 3-harness build pipeline (Claude Code, OpenCode, Codex)",
   "license": "MIT",
   "type": "module",

--- a/scripts/build-hooks.test.ts
+++ b/scripts/build-hooks.test.ts
@@ -205,8 +205,10 @@ import {
   existsSync,
   mkdirSync,
   writeFileSync,
+  rmSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { parse as parseYaml } from "yaml";
 
@@ -402,15 +404,49 @@ function compileHandlers(hooks: HookEntry[]): void {
   mkdirSync(DIST_HOOKS_DIR, { recursive: true });
   for (const hook of hooks) {
     const outFile = join(DIST_HOOKS_DIR, \`\${hook.name}.js\`);
+    const entryDir = join(tmpdir(), \`nexus-hook-entry-\${hook.name}-\${Date.now()}\`);
+    mkdirSync(entryDir, { recursive: true });
+    const entryFile = join(entryDir, \`\${hook.name}-entry.ts\`);
     try {
-      execSync(
-        \`bun build \${hook.handlerPath} --outfile \${outFile} --target node --format esm\`,
-        { cwd: ROOT, stdio: "inherit" },
+      const entryContent = [
+        \`import handler from \${JSON.stringify(hook.handlerPath)};\`,
+        \`import { readFileSync } from "node:fs";\`,
+        \`async function main() {\`,
+        \`  let raw = "";\`,
+        \`  try { raw = readFileSync(0, "utf-8"); } catch {}\`,
+        \`  const input = raw ? JSON.parse(raw) : {};\`,
+        \`  const result = await handler(input);\`,
+        \`  if (result != null && result !== undefined) {\`,
+        \`    process.stdout.write(JSON.stringify(result));\`,
+        \`  }\`,
+        \`}\`,
+        \`main().then(\`,
+        \`  () => process.exit(0),\`,
+        \`  (err) => { process.stderr.write(String(err?.stack ?? err) + "\\\\n"); process.exit(1); }\`,
+        \`);\`,
+      ].join("\\n") + "\\n";
+      writeFileSync(entryFile, entryContent);
+      try {
+        execSync(
+          \`bun build \${entryFile} --outfile \${outFile} --target node --format esm\`,
+          { cwd: ROOT, stdio: "inherit" },
+        );
+      } catch {
+        throw new Error(
+          \`[build-hooks] Handler compilation failed for "\${hook.name}" (bun build exit non-zero)\`,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        \`[build-hooks] wrapper-emit failed for "\${hook.name}": \${String(err)}\\n\`,
       );
-    } catch {
-      throw new Error(
-        \`[build-hooks] Handler compilation failed for "\${hook.name}" (bun build exit non-zero)\`,
-      );
+      throw err;
+    } finally {
+      try {
+        rmSync(entryDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
     }
   }
 }
@@ -831,6 +867,58 @@ describe("Scenario 1 — 정상 5 hook 빌드, 3 manifest 유효 JSON", () => {
     for (const hook of fiveHookFixture()) {
       expect(existsSync(join(hooksDistDir, `${hook.name}.js`))).toBe(true);
     }
+  });
+
+  test("compiled bundle contains bootstrap marker (readFileSync(0 or process.exit)", () => {
+    const { fixtureRoot, wrapperPath } = makeTmpAndWrapper(
+      fiveHookFixture(),
+      minimalCapabilityMatrix(),
+    );
+
+    runBuild(fixtureRoot, wrapperPath);
+
+    const hooksDistDir = join(fixtureRoot, "dist", "hooks");
+    // Check at least one hook that is registered (session-init is core/registered in all harnesses)
+    const bundlePath = join(hooksDistDir, "session-init.js");
+    expect(existsSync(bundlePath)).toBe(true);
+    const content = readFileSync(bundlePath, "utf-8");
+    const hasBootstrap =
+      content.includes("readFileSync(0") ||
+      content.includes("process.stdin") ||
+      content.includes("process.exit");
+    expect(hasBootstrap).toBe(true);
+  });
+
+  test("smoke: real dist/hooks/session-init.js exits 0 and creates state files for SessionStart payload", () => {
+    const realBundle = join(REPO_ROOT, "dist", "hooks", "session-init.js");
+    if (!existsSync(realBundle)) {
+      // Skip if the bundle hasn't been built yet (CI gate runs build first)
+      console.warn("[smoke] dist/hooks/session-init.js not found — skipping smoke test");
+      return;
+    }
+
+    const smokeDir = mkdtempSync(join(tmpdir(), "nexus-smoke-"));
+    tmpDirs.push(smokeDir);
+
+    const payload = JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: "smoke-t1",
+      cwd: smokeDir,
+      source: "startup",
+    });
+
+    const result = spawnSync("node", [realBundle], {
+      input: payload,
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+
+    if (result.status !== 0) {
+      console.error("smoke stderr:", result.stderr);
+    }
+    expect(result.status).toBe(0);
+    expect(existsSync(join(smokeDir, ".nexus", "state", "smoke-t1", "agent-tracker.json"))).toBe(true);
+    expect(existsSync(join(smokeDir, ".nexus", "state", "smoke-t1", "tool-log.jsonl"))).toBe(true);
   });
 });
 

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -22,8 +22,10 @@ import {
   mkdirSync,
   writeFileSync,
   copyFileSync,
+  rmSync,
 } from "node:fs";
 import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 import { parse as parseYaml } from "yaml";
@@ -321,15 +323,52 @@ function compileHandlers(plans: PortabilityPlan[], hookIndex: Map<string, HookEn
     if (!hook) continue;
 
     const outFile = join(DIST_HOOKS_DIR, `${hook.name}.js`);
+    const entryDir = join(tmpdir(), `nexus-hook-entry-${hook.name}-${Date.now()}`);
+    mkdirSync(entryDir, { recursive: true });
+    const entryFile = join(entryDir, `${hook.name}-entry.ts`);
+
     try {
-      execSync(
-        `bun build ${hook.handlerPath} --outfile ${outFile} --target node --format esm`,
-        { cwd: ROOT, stdio: "inherit" },
+      const entryContent = [
+        `import handler from ${JSON.stringify(hook.handlerPath)};`,
+        `import { readFileSync } from "node:fs";`,
+        `async function main() {`,
+        `  let raw = "";`,
+        `  try { raw = readFileSync(0, "utf-8"); } catch {}`,
+        `  const input = raw ? JSON.parse(raw) : {};`,
+        `  const result = await handler(input);`,
+        `  if (result != null && result !== undefined) {`,
+        `    process.stdout.write(JSON.stringify(result));`,
+        `  }`,
+        `}`,
+        `main().then(`,
+        `  () => process.exit(0),`,
+        `  (err) => { process.stderr.write(String(err?.stack ?? err) + "\\n"); process.exit(1); }`,
+        `);`,
+      ].join("\n") + "\n";
+
+      writeFileSync(entryFile, entryContent);
+
+      try {
+        execSync(
+          `bun build ${entryFile} --outfile ${outFile} --target node --format esm`,
+          { cwd: ROOT, stdio: "inherit" },
+        );
+      } catch {
+        throw new Error(
+          `[build-hooks] Handler compilation failed for "${hook.name}" (bun build exit non-zero)`,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(
+        `[build-hooks] wrapper-emit failed for "${hook.name}": ${String(err)}\n`,
       );
-    } catch {
-      throw new Error(
-        `[build-hooks] Handler compilation failed for "${hook.name}" (bun build exit non-zero)`,
-      );
+      throw err;
+    } finally {
+      try {
+        rmSync(entryDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- `assets/hooks/*/handler.ts`가 `export default handler`만 담아 `node dist/hooks/<n>.js` 실행과 OpenCode `spawn+stdin` 경로 모두에서 handler가 호출되지 않고 silent no-op으로 exit 0이 발생하던 critical 버그 수정 (#39).
- `scripts/build-hooks.ts:compileHandlers()`가 hook별 임시 entry 파일을 emit한 뒤 `bun build`에 입력으로 주입. Entry가 stdin→JSON.parse→handler invoke→stdout write를 수행하여 번들이 CLI 진입점으로 동작.
- 세 harness(Claude/Codex/OpenCode) 공통으로 SessionStart `.nexus/state` 생성, prompt-router tag dispatch, agent-tracker 기록, SubagentStop additional_context 주입 경로 전부 복구.

## Affected issues

- Closes #39

## Test plan

- [x] `bun run build` 성공 (5 hooks processed, 4 registered core tier)
- [x] `bun test` 전체 475 pass / 0 fail
- [x] `scripts/build-hooks.test.ts` 23 pass (bootstrap marker check + smoke test 포함)
- [x] Claude 경로: `echo '{...}' | node dist/hooks/session-init.js` → exit 0, `.nexus/state/<sid>/agent-tracker.json` + `tool-log.jsonl` 생성
- [x] OpenCode 경로: `child_process.spawn + stdin.write + JSON.parse(stdout)` 모사 → handler 정상 호출, 반환 없는 경우 빈 stdout으로 `opencode-mount.ts:331`의 `stdout ? JSON.parse(...) : null` 분기와 호환
- [x] 4개 registered handler(session-init, prompt-router, agent-bootstrap, agent-finalize) 각각 실행 시 handler 진입 확인
- [x] malformed JSON stdin → stderr에 SyntaxError 스택 + exit 1

## Release

tag `v0.15.2` push로 `.github/workflows/publish-npm.yml`이 자동 트리거되어 npm에 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)