### PR TITLE
fix(hooks): v0.16.1 — prompt-router bundle self-contained + smoke-consumer gate (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+## [0.16.1] - 2026-04-20
+
+### Fixed
+
+- v0.16.0에서 `prompt-router` 번들이 런타임에 `assets/tools/tool-name-map.yml`을 consumer target 트리 상향 탐색으로 찾다가 실패해 `UserPromptSubmit` hook이 exit 1로 throw하던 regression ([#46](https://github.com/moreih29/nexus-core/issues/46)).
+  `scripts/build-hooks.ts:compileHandlers()`가 `prompt-router` entry에만 `tool-name-map.yml`의 `invocations` 섹션과 `assets/agents`·`assets/skills` 디렉토리 이름 배열을 JSON으로 parse해 `globalThis.__NEXUS_INLINE_INVOCATIONS__`·`__NEXUS_INLINE_RULE_TARGETS__`에 주입하고, `assets/hooks/prompt-router/handler.ts:loadInvocations()`·`loadValidRuleTargets()`가 이 globalThis 값을 우선 사용하도록 변경되었습니다. 기존 FS 상향 탐색 경로는 nexus-core source tree 내 dev 시나리오를 위해 fallback으로 유지됩니다.
+  영향: consumer plugin에서 `[run]`·`[plan]`·`[sync]`·`[d]`·`[m]`·`[rule]` tag dispatch가 모두 복구됩니다.
+
+### Added
+
+- `scripts/smoke/smoke-consumer.ts` — distribution-invariant smoke gate. `mkdtemp` 타깃에 `sync --harness=claude`를 실행한 뒤 `prompt-router`에 `[run]` / `[rule]` payload를 주입하여 `exit 0` + `<system-notice>` stdout을 assert합니다. `bun run smoke` aggregate 체인 끝에 추가되어 `validate.yml`·`publish-npm.yml` CI에서 자동 실행되며, source-tree 기반 기존 smoke가 놓치는 consumer-install 시나리오 class를 차단합니다.
+
+### Migration Notes
+
+- `bun add @moreih29/nexus-core@^0.16.1` / `npm i @moreih29/nexus-core@0.16.1`로 bump 후 `bun run sync`로 번들을 target에 재배포하세요.
+- v0.16.0은 `prompt-router`가 항상 throw하므로 **deprecate 권장**.
+
+---
+
 ## [0.16.0] - 2026-04-20
 
 ### BREAKING CHANGES

--- a/assets/hooks/prompt-router/handler.ts
+++ b/assets/hooks/prompt-router/handler.ts
@@ -32,6 +32,13 @@ let _invocationsCache: InvocationsMap | null = null;
 function loadInvocations(): InvocationsMap {
   if (_invocationsCache) return _invocationsCache;
 
+  // In the compiled consumer bundle, assets/ is absent — use data inlined at build time.
+  const inlined = (globalThis as unknown as { __NEXUS_INLINE_INVOCATIONS__?: InvocationsMap }).__NEXUS_INLINE_INVOCATIONS__;
+  if (inlined) {
+    _invocationsCache = inlined;
+    return inlined;
+  }
+
   const selfDir = new URL(".", import.meta.url).pathname;
   // Walk up from handler directory to find assets/tools/tool-name-map.yml
   let dir = selfDir;
@@ -82,6 +89,10 @@ function expand(template: string, harness: Harness): string {
 // ---------------------------------------------------------------------------
 
 function loadValidRuleTargets(cwd: string): string[] {
+  // In the compiled consumer bundle, cwd/assets/ is absent — use data inlined at build time.
+  const inlined = (globalThis as unknown as { __NEXUS_INLINE_RULE_TARGETS__?: string[] }).__NEXUS_INLINE_RULE_TARGETS__;
+  if (inlined && inlined.length > 0) return inlined;
+
   const targets: string[] = [];
   for (const dir of ["assets/agents", "assets/skills"]) {
     const absDir = join(cwd, dir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Nexus ecosystem authoring layer — canonical agents/skills/hooks and 3-harness build pipeline (Claude Code, OpenCode, Codex)",
   "license": "MIT",
   "type": "module",
@@ -61,7 +61,8 @@
     "smoke:claude": "bun run scripts/smoke/smoke-claude.ts",
     "smoke:codex": "bun run scripts/smoke/smoke-codex.ts",
     "smoke:opencode": "bun run scripts/smoke/smoke-opencode.ts",
-    "smoke": "bun run smoke:claude && bun run smoke:codex && bun run smoke:opencode"
+    "smoke:consumer": "bun run scripts/smoke/smoke-consumer.ts",
+    "smoke": "bun run smoke:claude && bun run smoke:codex && bun run smoke:opencode && bun run smoke:consumer"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/scripts/build-hooks.test.ts
+++ b/scripts/build-hooks.test.ts
@@ -69,6 +69,14 @@ function createFixtureDir(
   mkdirSync(toolsDir, { recursive: true });
   writeFileSync(join(toolsDir, "tool-name-map.yml"), toolNameMap ?? defaultToolNameMap());
 
+  // Minimal agents + skills dirs — required for prompt-router inline data injection.
+  for (const agentName of ["engineer", "architect"]) {
+    mkdirSync(join(tmp, "assets", "agents", agentName), { recursive: true });
+  }
+  for (const skillName of ["nx-plan", "nx-run"]) {
+    mkdirSync(join(tmp, "assets", "skills", skillName), { recursive: true });
+  }
+
   // hook dirs
   for (const hook of hooks) {
     const dir = join(hooksDir, hook.name);
@@ -115,6 +123,13 @@ function defaultToolNameMap(): string {
     claude: [Edit, MultiEdit]
     codex: apply_patch
     opencode: [apply_patch, edit]
+invocations:
+  skill_activation:
+    args: [skill, mode]
+    templates:
+      claude: 'Skill({ command: "{skill}" })'
+      opencode: 'skill({ name: "{skill}" })'
+      codex: '\${skill}'
 `;
 }
 
@@ -408,7 +423,28 @@ function compileHandlers(hooks: HookEntry[]): void {
     mkdirSync(entryDir, { recursive: true });
     const entryFile = join(entryDir, \`\${hook.name}-entry.ts\`);
     try {
-      const entryContent = [
+      const lines: string[] = [];
+
+      if (hook.name === "prompt-router") {
+        const toolNameMapRaw = readFileSync(TOOL_NAME_MAP_PATH, "utf-8");
+        const toolNameMapParsed = parseYaml(toolNameMapRaw) as { invocations?: unknown };
+        const invocationsJson = JSON.stringify(toolNameMapParsed.invocations ?? {});
+
+        const agentsDir = join(ROOT, "assets/agents");
+        const skillsDir = join(ROOT, "assets/skills");
+        const agentNames = existsSync(agentsDir)
+          ? readdirSync(agentsDir, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name)
+          : [];
+        const skillNames = existsSync(skillsDir)
+          ? readdirSync(skillsDir, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name)
+          : [];
+        const ruleTargetsJson = JSON.stringify([...agentNames, ...skillNames]);
+
+        lines.push("globalThis.__NEXUS_INLINE_INVOCATIONS__ = " + invocationsJson + ";");
+        lines.push("globalThis.__NEXUS_INLINE_RULE_TARGETS__ = " + ruleTargetsJson + ";");
+      }
+
+      lines.push(
         \`import handler from \${JSON.stringify(hook.handlerPath)};\`,
         \`import { readFileSync } from "node:fs";\`,
         \`async function main() {\`,
@@ -424,7 +460,9 @@ function compileHandlers(hooks: HookEntry[]): void {
         \`  () => process.exit(0),\`,
         \`  (err) => { process.stderr.write(String(err?.stack ?? err) + "\\\\n"); process.exit(1); }\`,
         \`);\`,
-      ].join("\\n") + "\\n";
+      );
+
+      const entryContent = lines.join("\\n") + "\\n";
       writeFileSync(entryFile, entryContent);
       try {
         execSync(
@@ -1464,6 +1502,42 @@ requires_capabilities:
 
     expect(first).toContain("hook-priority-99");
     expect(second).toContain("hook-priority-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 9: prompt-router 번들에 inline 데이터 포함, 다른 hook에는 없음
+// ---------------------------------------------------------------------------
+
+describe("Scenario 9 — prompt-router inline invocations + rule_targets", () => {
+  test("prompt-router bundle contains __NEXUS_INLINE_INVOCATIONS__ and __NEXUS_INLINE_RULE_TARGETS__", () => {
+    const { fixtureRoot, wrapperPath } = makeTmpAndWrapper(
+      fiveHookFixture(),
+      minimalCapabilityMatrix(),
+    );
+
+    runBuild(fixtureRoot, wrapperPath);
+
+    const bundlePath = join(fixtureRoot, "dist", "hooks", "prompt-router.js");
+    expect(existsSync(bundlePath)).toBe(true);
+    const content = readFileSync(bundlePath, "utf-8");
+    expect(content.includes("__NEXUS_INLINE_INVOCATIONS__")).toBe(true);
+    expect(content.includes("__NEXUS_INLINE_RULE_TARGETS__")).toBe(true);
+  });
+
+  test("session-init bundle does NOT contain __NEXUS_INLINE_INVOCATIONS__ or __NEXUS_INLINE_RULE_TARGETS__", () => {
+    const { fixtureRoot, wrapperPath } = makeTmpAndWrapper(
+      fiveHookFixture(),
+      minimalCapabilityMatrix(),
+    );
+
+    runBuild(fixtureRoot, wrapperPath);
+
+    const bundlePath = join(fixtureRoot, "dist", "hooks", "session-init.js");
+    expect(existsSync(bundlePath)).toBe(true);
+    const content = readFileSync(bundlePath, "utf-8");
+    expect(content.includes("__NEXUS_INLINE_INVOCATIONS__")).toBe(false);
+    expect(content.includes("__NEXUS_INLINE_RULE_TARGETS__")).toBe(false);
   });
 });
 

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -328,7 +328,35 @@ function compileHandlers(plans: PortabilityPlan[], hookIndex: Map<string, HookEn
     const entryFile = join(entryDir, `${hook.name}-entry.ts`);
 
     try {
-      const entryContent = [
+      // Build the entry lines array. For prompt-router, inline assets data that
+      // won't be available in a consumer target (#46: assets/ not present at runtime).
+      const lines: string[] = [];
+
+      if (hook.name === "prompt-router") {
+        // Inline invocations map from tool-name-map.yml so prompt-router bundle
+        // is self-contained — consumer targets have no assets/ directory (#46).
+        const toolNameMapRaw = readFileSync(TOOL_NAME_MAP_PATH, "utf-8");
+        const toolNameMapParsed = parseYaml(toolNameMapRaw) as { invocations?: unknown };
+        const invocationsJson = JSON.stringify(toolNameMapParsed.invocations ?? {});
+
+        // Inline rule targets (agents + skills directory names) for [rule] tag handling.
+        const agentsDir = join(ROOT, "assets/agents");
+        const skillsDir = join(ROOT, "assets/skills");
+        const agentNames = readdirSync(agentsDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name);
+        const skillNames = readdirSync(skillsDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name);
+        const ruleTargetsJson = JSON.stringify([...agentNames, ...skillNames]);
+
+        // Assign to globalThis before the handler import so the module reads
+        // these values at load time (cache check runs on first loadInvocations() call).
+        lines.push("globalThis.__NEXUS_INLINE_INVOCATIONS__ = " + invocationsJson + ";");
+        lines.push("globalThis.__NEXUS_INLINE_RULE_TARGETS__ = " + ruleTargetsJson + ";");
+      }
+
+      lines.push(
         `import handler from ${JSON.stringify(hook.handlerPath)};`,
         `import { readFileSync } from "node:fs";`,
         `async function main() {`,
@@ -344,7 +372,9 @@ function compileHandlers(plans: PortabilityPlan[], hookIndex: Map<string, HookEn
         `  () => process.exit(0),`,
         `  (err) => { process.stderr.write(String(err?.stack ?? err) + "\\n"); process.exit(1); }`,
         `);`,
-      ].join("\n") + "\n";
+      );
+
+      const entryContent = lines.join("\n") + "\n";
 
       writeFileSync(entryFile, entryContent);
 

--- a/scripts/smoke/smoke-consumer.ts
+++ b/scripts/smoke/smoke-consumer.ts
@@ -1,0 +1,106 @@
+// Issue #46 — prompt-router runtime asset lookup 회귀 감지 (fresh consumer target 모사)
+
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { findPackageRoot } from "../../src/shared/package-root.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = findPackageRoot(__dirname);
+
+function fail(msg: string): never {
+  process.stderr.write(`[smoke-consumer] FAIL: ${msg}\n`);
+  process.exit(1);
+}
+
+function spawnWithStdin(
+  handlerPath: string,
+  payload: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("node", [handlerPath], { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+    child.stdin.write(payload);
+    child.stdin.end();
+    child.on("exit", (c) => resolve({ code: c ?? 1, stdout, stderr }));
+    child.on("error", () => resolve({ code: 1, stdout, stderr }));
+  });
+}
+
+const tmpDir = mkdtempSync(join(tmpdir(), "nexus-smoke-consumer-"));
+
+try {
+  // 1. Sync to fresh consumer target — simulates downstream consumer install
+  execSync(
+    `node ${join(ROOT, "dist/scripts/cli.js")} sync --harness=claude --target=${tmpDir}`,
+    { stdio: "ignore" },
+  );
+
+  const handlerPath = join(tmpDir, "dist/hooks/prompt-router.js");
+  if (!existsSync(handlerPath)) {
+    fail(`prompt-router.js not found at ${handlerPath} — sync may have failed or bundle name changed`);
+  }
+
+  // Case A: [run] tag → exit 0 + stdout contains <system-notice>
+  const payloadA = JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    session_id: "smoke-run",
+    cwd: tmpDir,
+    prompt: "[run] smoke",
+  });
+
+  const resultA = await spawnWithStdin(handlerPath, payloadA);
+  if (resultA.code !== 0) {
+    fail(
+      `case A ([run]) exited with code ${resultA.code}\n` +
+      `  stdout: ${resultA.stdout.slice(0, 300)}\n` +
+      `  stderr: ${resultA.stderr.slice(0, 300)}`,
+    );
+  }
+  if (!resultA.stdout.includes("<system-notice>")) {
+    fail(
+      `case A ([run]) stdout missing <system-notice>\n` +
+      `  stdout: ${resultA.stdout.slice(0, 300)}\n` +
+      `  stderr: ${resultA.stderr.slice(0, 300)}`,
+    );
+  }
+
+  // Case B: [rule] tag → exit 0 + stdout contains "Valid targets:" + at least one name
+  const payloadB = JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    session_id: "smoke-rule",
+    cwd: tmpDir,
+    prompt: "[rule] store this convention",
+  });
+
+  const resultB = await spawnWithStdin(handlerPath, payloadB);
+  if (resultB.code !== 0) {
+    fail(
+      `case B ([rule]) exited with code ${resultB.code}\n` +
+      `  stdout: ${resultB.stdout.slice(0, 300)}\n` +
+      `  stderr: ${resultB.stderr.slice(0, 300)}`,
+    );
+  }
+  if (!resultB.stdout.includes("Valid targets:")) {
+    fail(
+      `case B ([rule]) stdout missing "Valid targets:"\n` +
+      `  stdout: ${resultB.stdout.slice(0, 300)}\n` +
+      `  stderr: ${resultB.stderr.slice(0, 300)}`,
+    );
+  }
+  if (!/Valid targets:[^.]*[a-zA-Z0-9_-]+/.test(resultB.stdout)) {
+    fail(
+      `case B ([rule]) "Valid targets:" not followed by at least one name\n` +
+      `  stdout: ${resultB.stdout.slice(0, 300)}`,
+    );
+  }
+
+  console.log("[smoke-consumer] PASS — prompt-router emits system-notice for [run] + [rule] tags in fresh consumer target");
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- v0.16.0의 `prompt-router` 번들이 런타임에 `assets/tools/tool-name-map.yml`과 `assets/agents`·`assets/skills`를 selfDir 상향 FS lookup으로 찾다가 consumer target 레이아웃에서 실패, `UserPromptSubmit` 훅이 exit 1로 throw하던 regression 수정 (#46).
- `scripts/build-hooks.ts:compileHandlers()`가 `prompt-router` entry에만 `tool-name-map.yml`의 `invocations`와 `assets/agents`·`assets/skills` 디렉토리 이름 배열을 JSON으로 parse해 `globalThis.__NEXUS_INLINE_INVOCATIONS__`·`__NEXUS_INLINE_RULE_TARGETS__`에 주입. `assets/hooks/prompt-router/handler.ts`의 `loadInvocations()`·`loadValidRuleTargets()`는 이 globalThis 값을 우선 사용, 기존 FS 탐색은 source-tree dev 시나리오용 fallback으로 유지.
- `scripts/smoke/smoke-consumer.ts` 신설 — `mktemp` 타깃에 `sync --harness=claude` 실행 → `prompt-router`에 `[run]` / `[rule]` payload를 stdin 주입 → `exit 0` + `<system-notice>` stdout을 assert. `bun run smoke` aggregate에 체인되어 `validate.yml`·`publish-npm.yml` CI가 동일 class의 regression을 publish 전 차단.

## Affected issues

- Closes #46

## Test plan

- [x] `bun run clean && bun run build` 성공
- [x] `bun run smoke` — 4개 러너 전량 PASS
  - smoke-claude: session-init side-effects
  - smoke-codex: 10개 TOML standalone schema
  - smoke-opencode: manifest + spawn + side-effects
  - smoke-consumer: fresh-sync target에 prompt-router `[run]` / `[rule]` emit
- [x] `bun test` 전체 592 pass / 0 fail
- [x] fresh consumer 재현: `/tmp/nxt46-t1`에 sync 후 `[run]` payload → exit 0 + `<system-notice>` stdout / `[rule]` payload → exit 0 + `Valid targets: strategist, reviewer, writer, lead, architect, designer, tester, postdoc, researcher, engineer, nx-sync, nx-run, nx-init, nx-plan`
- [x] `grep -c __NEXUS_INLINE_INVOCATIONS__ dist/hooks/prompt-router.js` = 2 / `dist/hooks/session-init.js` = 0 (prompt-router 전용 주입 확인)

## Release

tag `v0.16.1` push → `publish-npm.yml` 자동 트리거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)