### PR TITLE
fix(codex): v0.16.2 — root-level disabled_tools를 [mcp_servers.nx] 블록으로 이동 (#48)

### DIFF
--- a/.nexus/history.json
+++ b/.nexus/history.json
@@ -6277,6 +6277,114 @@
           "created_at": "2026-04-20T08:04:44.447Z"
         }
       ]
+    },
+    {
+      "schema_version": "0.5",
+      "completed_at": "2026-04-20T08:38:44.574Z",
+      "branch": "fix/issue-48-codex-mcp-servers-block",
+      "plan": {
+        "id": 20,
+        "topic": "Issue #48: Codex standalone role TOML의 disabled_tools를 [mcp_servers.nx] 블록 하위로 이동 (v0.16.2)",
+        "issues": [
+          {
+            "id": 1,
+            "title": "Codex role file [mcp_servers.nx] 블록 스키마 결정 (command/args 포함 여부)",
+            "status": "decided",
+            "decision": "[mcp_servers.nx] 블록에 `command = \"nexus-mcp\"` + `disabled_tools = [...]` 포함. args는 생략.\n\n근거: package.json bin의 nexus-mcp 바이너리는 args 없이 실행되므로 빈 배열은 noise. command는 RawMcpServerConfig의 필드 required 여부 불확실성에 대한 보수적 대응. 기존 install/config.fragment.toml과 일관된 형태 유지.\n\n거부된 대안:\n- (a) disabled_tools만 포함 — RawMcpServerConfig가 command를 required로 요구하면 또 다른 parse 에러 리스크. 보수적으로 command 포함이 안전.\n- (b) command + args=[] 명시 — package.json bin 엔트리에 args 정의 없음. 명시적 빈 배열은 불필요한 noise."
+          },
+          {
+            "id": 2,
+            "title": "scripts/build-agents.ts codexAgentToml() 수정 및 테스트 업데이트 범위",
+            "status": "decided",
+            "decision": "codexAgentToml() 수정 방식:\n- `disabled_tools.length > 0`일 때만 `[mcp_servers.nx]` 블록 emit (이전 root-level `disabled_tools` 라인은 완전 제거)\n- 블록 구조: `[mcp_servers.nx]` 헤더 → `command = \"nexus-mcp\"` → `disabled_tools = [...]`\n- command 상수를 모듈 스코프 상수로 추출하여 `codexConfigFragment()`와 공유 (drift 방지)\n\n테스트 업데이트 (scripts/build-agents.test.ts):\n- 기존 L612-627 테스트에 root-level `disabled_tools = [` 미포함 assertion 추가\n- `[mcp_servers.nx]` 블록 존재 assertion 추가\n- 블록 하위 `disabled_tools` assertion 추가 (블록 헤더 이후 줄에 존재)\n- resolveCodexConfig 단위 테스트는 변경 없음 (API 유지)\n\n거부된 대안:\n- (a) 항상 [mcp_servers.nx] 블록 emit — disabled_tools 빈 경우 불필요한 블록이 소비자 install flow에 noise\n- (b) command 상수 분리 유지 — fragment와 standalone에서 drift 시 debugging 어려움"
+          },
+          {
+            "id": 3,
+            "title": "docs/contract/harness-io.md + CHANGELOG.md v0.16.2 문서 업데이트",
+            "status": "decided",
+            "decision": "문서 업데이트:\n1. **docs/contract/harness-io.md L201-212**: Codex standalone role schema 예시에서 root-level `disabled_tools` 제거 + `[mcp_servers.nx]` 블록 추가 (command + disabled_tools). 주의 박스에 \"disabled_tools는 반드시 [mcp_servers.<id>] 블록 하위\"임을 명시.\n\n2. **CHANGELOG.md v0.16.2 엔트리**:\n   - `### Fixed` — 이슈 #48 해결: root-level disabled_tools가 Codex 0.121 deny_unknown_fields에 reject되던 문제. [mcp_servers.nx] 블록 하위로 이동.\n   - `### Migration Notes` — consumer는 `bun add @moreih29/nexus-core@^0.16.2` 후 sync 재실행. 기존에 설치된 role file을 Codex가 경고 없이 로드하는지 확인.\n\n3. **.nexus/memory/external-harness-agent-permissions.md §4**: v0.16.0 일탈 → v0.16.2 복원 사실을 짧은 노트로 추가 (trailing \"## 검증 내역\" 같은 섹션이나 §4 말미).\n\n거부된 대안:\n- 최소 업데이트 (CHANGELOG만) — 소비자가 harness-io.md를 계약 기준으로 봤을 때 root-level disabled_tools가 여전히 스펙처럼 보여 혼동. 계약 문서는 반드시 동기화."
+          },
+          {
+            "id": 4,
+            "title": "package.json version bump 0.16.1 → 0.16.2 및 .nexus/memory 보강",
+            "status": "decided",
+            "decision": "package.json version: 0.16.1 → 0.16.2 (SemVer patch bump).\n\n근거: 소비자 API 변화 없음 — 오직 Codex 산출물 TOML 구조만 수정(버그 픽스). BREAKING 없음. harness-io.md 계약 문서의 표현형만 변경되지만 실제로는 v0.16.0부터 이미 깨져 있던 것이므로 \"실사용 측 회복\"에 해당 → patch가 적절.\n\n거부된 대안:\n- 0.17.0 minor bump — BREAKING 없고 기능 추가도 아님. patch가 정확.\n- 0.16.1 유지(hotfix tag) — npm publish flow상 새 버전 필요.\n\nmemory 업데이트는 Decision 3에 이미 포함 (§4 v0.16.2 복원 노트)."
+          }
+        ],
+        "research_summary": "Codex rust-v0.121.0 소스(commit b3442f5) 분석 결과:\n\n1. RawAgentRoleFileToml은 serde-level deny_unknown_fields로 root-level disabled_tools를 reject. ConfigToml은 schemars-level만 (런타임 통과). ConfigToml.mcp_servers: HashMap<String, McpServerConfig>에서 RawMcpServerConfig가 disabled_tools/enabled_tools 정식 수용.\n\n2. nexus-core 현재 구조:\n- scripts/build-agents.ts L764-789 codexAgentToml(): root-level disabled_tools 출력 (버그)\n- scripts/build-agents.ts L844-853 codexConfigFragment(): 별도 config.fragment.toml에 [mcp_servers.nx] command=\"nexus-mcp\" 제공 (global config.toml에 merge 용도)\n- package.json bin: nexus-mcp → ./dist/src/mcp/server.js, args 없음\n- 따라서 standalone role file의 [mcp_servers.nx]에도 command=\"nexus-mcp\" 포함이 자연스러움\n\n3. Capability matrix (assets/capability-matrix.yml):\n- no_task_create: codex.disabled_tools=[nx_task_add]\n- no_task_update: codex.disabled_tools=[nx_task_update]\n- no_file_edit: codex.sandbox_mode=read-only (disabled_tools는 빈 배열)\n\n4. 메모 .nexus/memory/external-harness-agent-permissions.md §4·§6가 원래부터 \"Codex는 [mcp_servers.<id>] disabled_tools로 런타임 강제\" 규정 → v0.16.0 일탈 복원\n\n5. 기존 테스트: resolveCodexConfig 3개(L436-450), 전체 TOML 2개(L612-666). 새 테스트는 root-level disabled_tools 없음 + [mcp_servers.nx] 블록 존재 + 블록 하위 disabled_tools 검증 추가.\n\n6. CHANGELOG 형식: ## [VER] - DATE → ### Fixed/Added/Migration Notes. docs/contract/harness-io.md L201-212가 root-level disabled_tools를 스키마로 문서화 중 → 업데이트 필요.",
+        "created_at": "2026-04-20T08:26:14.842Z"
+      },
+      "tasks": [
+        {
+          "id": 1,
+          "title": "codexAgentToml() 수정 + 테스트 업데이트",
+          "context": "scripts/build-agents.ts L764-789 codexAgentToml() 함수가 root-level `disabled_tools = [...]`를 emit 중이나 Codex 0.121의 RawAgentRoleFileToml이 serde deny_unknown_fields로 reject하여 role 전체 무시됨 (Issue #48). v0.16.0 standalone 전환 시 [mcp_servers.<id>] 하위로 배치하려던 원래 설계(메모리 §4)에서 일탈한 버그를 복원.\n\n참조:\n- 현재 코드: scripts/build-agents.ts L764-789 (codexAgentToml), L844-853 (codexConfigFragment: `command = \"nexus-mcp\"`)\n- 테스트: scripts/build-agents.test.ts L436-450 (resolveCodexConfig 3개), L612-627 (Codex standalone TOML), L657-666 (config.fragment)\n- Capability matrix: assets/capability-matrix.yml L122-147\n- Codex source 검증: commit b3442f5 (tag rust-v0.121.0), codex-rs/core/src/config/agent_roles.rs, codex-rs/config/src/config_toml.rs, codex-rs/config/src/mcp_types.rs",
+          "approach": "1. scripts/build-agents.ts 수정:\n   - 모듈 스코프 상수 추가: `const CODEX_MCP_NX_COMMAND = \"nexus-mcp\";`\n   - codexAgentToml() (L764-789): root-level `disabled_tools = [...]` 라인 제거. 대신 `disabled_tools.length > 0`일 때 다음을 append:\n     ```\n     [mcp_servers.nx]\n     command = \"nexus-mcp\"\n     disabled_tools = [\"nx_task_add\", ...]\n     ```\n   - codexConfigFragment() (L844-853): 같은 상수를 참조하도록 리팩터 (drift 방지)\n   - resolveCodexConfig() 시그니처/동작은 유지\n\n2. scripts/build-agents.test.ts 업데이트:\n   - 기존 L612-627 \"agents/<n>.toml is created with standalone role schema\" 테스트를 확장: root-level `disabled_tools` 부재(`/^disabled_tools = /m` not match), `[mcp_servers.nx]` 블록 존재, 블록 내부의 `disabled_tools` 존재 검증. makeAgentEntry()에 no_task_create/no_task_update capability 포함되도록 조정하거나 별도 테스트 신규 추가.\n   - 새 테스트 \"Codex: agents/<n>.toml emits [mcp_servers.nx] with disabled_tools when capability present\" 추가하는 게 깔끔\n\n3. 실행 검증: `bun test scripts/build-agents.test.ts` 전체 통과. 관련 파일만 타깃.",
+          "acceptance": "- scripts/build-agents.ts의 codexAgentToml() 출력에서 root-level `disabled_tools =` 라인이 어떤 capability 조합에서도 나오지 않음\n- disabled_tools가 하나라도 있는 agent의 경우 `[mcp_servers.nx]` 블록 + 그 하위 `command = \"nexus-mcp\"` + `disabled_tools = [...]`이 생성됨\n- disabled_tools가 빈 경우 [mcp_servers.nx] 블록 자체가 생성되지 않음\n- `bun test scripts/build-agents.test.ts` 전체 통과 (기존 + 신규)\n- codexConfigFragment() 출력은 기존과 동일 유지 (command = \"nexus-mcp\"), drift 없음\n- resolveCodexConfig 단위 테스트 3개는 변경 없이 통과",
+          "risk": "- RawMcpServerConfig가 command 외에 type 등 추가 required 필드를 요구할 가능성 — Codex 0.121에서 stdio transport는 command만으로 deserialize 성공하는 것이 기본 동작이나, 확실한 보증은 실제 설치 후 smoke에서 확인 필요 (후속 tester task에서 검증)\n- 기존 test가 root-level disabled_tools를 assertion하고 있으면 수정 필요 (현재 L612-627 테스트는 해당 assertion 없음 — 확인 완료)",
+          "status": "completed",
+          "deps": [],
+          "plan_issue": 2,
+          "owner": "engineer",
+          "created_at": "2026-04-20T08:27:32.705Z"
+        },
+        {
+          "id": 2,
+          "title": "docs/contract/harness-io.md + CHANGELOG + memory 동기화",
+          "context": "Issue #48 수정에 따라 계약 문서 및 릴리스 문서를 v0.16.2로 정렬. harness-io.md가 현재 root-level disabled_tools를 계약으로 문서화 중이라 수정 필수. CHANGELOG는 기존 v0.16.0/v0.16.1 형식(## [VER] - DATE, ### Fixed/Added/Migration Notes) 준수.\n\n대상 파일:\n- docs/contract/harness-io.md (L201-212 부근: Codex standalone role schema 예시)\n- CHANGELOG.md (상단에 v0.16.2 엔트리 추가)\n- .nexus/memory/external-harness-agent-permissions.md (§4 Codex CLI 섹션에 v0.16.0/v0.16.2 히스토리 노트)\n\n오늘 날짜: 2026-04-20",
+          "approach": "1. **docs/contract/harness-io.md** (L201-212):\n   - 스키마 예시 코드블록에서 root-level `disabled_tools = [...]` 줄 제거\n   - 예시 아래에 `[mcp_servers.nx]` 블록 샘플 추가:\n     ```toml\n     [mcp_servers.nx]\n     command = \"nexus-mcp\"\n     disabled_tools = [\"nx_task_add\"]\n     ```\n   - 주의 박스 문구 업데이트: \"disabled_tools는 반드시 [mcp_servers.<id>] 블록 하위. root-level 배치는 Codex 0.121+가 deny_unknown_fields로 reject.\"\n\n2. **CHANGELOG.md** 상단에 v0.16.2 엔트리 삽입:\n   ```markdown\n   ## [0.16.2] - 2026-04-20\n\n   ### Fixed\n\n   - Codex standalone role file의 `disabled_tools`가 root-level로 방출되어 codex-cli 0.121+가 `deny_unknown_fields`로 role 전체를 reject하던 문제([#48](...)) 수정. `[mcp_servers.nx]` 테이블 블록 하위로 이동하여 Codex 스키마(RawMcpServerConfig) 적합.\n\n   ### Migration Notes\n\n   - Codex consumer: `bun add @moreih29/nexus-core@^0.16.2` 후 sync 재실행 (`nexus sync --harness=codex`). 기존 설치된 `~/.codex/agents/*.toml`은 덮어쓰기됨. codex CLI 시작 시 \"Ignoring malformed agent role definition\" 경고가 사라지는지 확인.\n\n   ---\n   ```\n   (기존 `## [0.16.1]` 섹션 위에 삽입, `---` 구분선 유지)\n\n3. **.nexus/memory/external-harness-agent-permissions.md §4 Codex CLI**:\n   - \"codex-nexus 변환 흐름\" 다이어그램 아래 또는 섹션 말미에 히스토리 노트 추가:\n     ```markdown\n     **nexus-core 히스토리**:\n     - v0.15.x: `[agents.<id>]` nested 테이블 + `[agents.<id>.mcp_servers.nx] disabled_tools`\n     - v0.16.0: standalone role file 전환 시 `[mcp_servers.nx]` 블록을 실수로 drop하고 root-level `disabled_tools` 방출 → codex-cli 0.121의 `RawAgentRoleFileToml` deny_unknown_fields에 reject (Issue #48)\n     - v0.16.2: standalone role file 구조 유지 + `[mcp_servers.nx] disabled_tools = [...]` 복원 (올바른 스키마)\n     ```",
+          "acceptance": "- docs/contract/harness-io.md에 root-level disabled_tools가 스키마 예시에서 사라지고 [mcp_servers.nx] 블록 예시로 교체됨\n- CHANGELOG.md 상단에 v0.16.2 엔트리가 기존 형식(## [VER] - DATE, ### Fixed, ### Migration Notes)으로 추가됨\n- .nexus/memory/external-harness-agent-permissions.md §4에 v0.15→v0.16.0→v0.16.2 히스토리 노트 추가\n- 모든 문서가 오늘 날짜 2026-04-20 반영\n- Issue #48 링크가 CHANGELOG에 포함",
+          "risk": "- harness-io.md의 다른 섹션에서 root-level disabled_tools를 재언급하는 부분이 있을 수 있음 — 전체 파일 grep으로 확인 후 일괄 정리",
+          "status": "completed",
+          "deps": [],
+          "plan_issue": 3,
+          "owner": "writer",
+          "created_at": "2026-04-20T08:27:57.354Z"
+        },
+        {
+          "id": 3,
+          "title": "package.json version bump 0.16.1 → 0.16.2",
+          "context": "SemVer patch bump. BREAKING 없음 — Codex TOML 산출물의 잘못된 스키마를 수정하는 버그픽스. package.json L3만 변경.",
+          "approach": "package.json L3의 `\"version\": \"0.16.1\"` → `\"version\": \"0.16.2\"`. Edit 도구로 한 줄만 변경.",
+          "acceptance": "- package.json의 version 필드가 \"0.16.2\"로 변경\n- 다른 필드 변경 없음",
+          "risk": "없음 (단순 버전 bump)",
+          "status": "completed",
+          "deps": [],
+          "plan_issue": 4,
+          "owner": "lead",
+          "created_at": "2026-04-20T08:28:04.348Z"
+        },
+        {
+          "id": 4,
+          "title": "engineer 작업물 검증 (bun test + 샘플 TOML 구조)",
+          "context": "Task #1 (engineer: codexAgentToml 수정 + 테스트) 완료 후 acceptance 검증. bun test 전체 통과 확인 + 실제로 생성된 Codex TOML 샘플이 TOML 문법 + Codex RawAgentRoleFileToml 스키마를 준수하는지 육안 검사.",
+          "approach": "1. `bun test scripts/build-agents.test.ts` 전체 통과 확인\n2. `bun run build` 실행하여 dist/codex/agents/*.toml 샘플 생성 — architect.toml, engineer.toml 등을 읽어 root-level disabled_tools 부재 + [mcp_servers.nx] 블록 + 블록 내 disabled_tools 확인\n3. 생성된 TOML이 유효한 TOML 문법인지 TOML parser로 parse 시도 (bun에 TOML 모듈 있으면 사용, 없으면 node 대체)\n4. resolveCodexConfig 단위 테스트 3개가 여전히 통과하는지 확인",
+          "acceptance": "- bun test 전체 통과 (scripts/build-agents.test.ts)\n- dist/codex/agents/architect.toml (혹은 HOW 계열)의 구조가 기대대로: root에 disabled_tools 없음, [mcp_servers.nx] + command + disabled_tools 포함\n- engineer 계열(no_task_create)도 [mcp_servers.nx] disabled_tools=[\"nx_task_add\"] 포함\n- TOML syntax 유효",
+          "risk": "bun run build가 여러 harness를 동시 생성 — 다른 harness 출력에 영향 없는지 smoke check 필요",
+          "status": "completed",
+          "deps": [
+            1
+          ],
+          "plan_issue": 2,
+          "owner": "tester",
+          "created_at": "2026-04-20T08:28:16.600Z"
+        },
+        {
+          "id": 5,
+          "title": "writer 작업물 검증 (문서 팩트·문법·형식)",
+          "context": "Task #2 (writer: harness-io.md + CHANGELOG + memory 동기화) 완료 후 팩트·문법·형식 검증. 문서 내용이 Issue #48의 실제 상황, Codex 0.121 스키마, engineer의 코드 변경과 일치하는지 확인.",
+          "approach": "1. harness-io.md 스키마 예시가 engineer가 만든 실제 TOML 산출물 구조와 일치하는지\n2. CHANGELOG v0.16.2 엔트리가 기존 v0.16.0/v0.16.1 형식(## [VER] - DATE, ### Fixed, ### Migration Notes)을 준수하는지\n3. Issue #48 GitHub 링크 포맷 (다른 CHANGELOG 엔트리의 링크 스타일과 일치)\n4. 한글 맞춤법, 기술 용어(deny_unknown_fields, RawAgentRoleFileToml 등) 정확 표기\n5. .nexus/memory §4 히스토리 노트가 연대순(v0.15→v0.16.0→v0.16.2)으로 정확한지",
+          "acceptance": "- 모든 문서의 기술 주장이 실제 코드·Codex 0.121 스키마와 일치\n- CHANGELOG 형식이 기존 엔트리와 동일\n- Issue #48 링크 포맷 정확\n- 한글 문장 완결성·맞춤법 통과",
+          "risk": "engineer 변경 내용을 writer가 추정으로 썼을 경우 불일치 가능 — Task #1·#4 완료 후 실행해야 검증 의미가 있음",
+          "status": "completed",
+          "deps": [
+            2
+          ],
+          "plan_issue": 3,
+          "owner": "reviewer",
+          "created_at": "2026-04-20T08:28:30.055Z"
+        }
+      ]
     }
   ]
 }

--- a/.nexus/memory/external-harness-agent-permissions.md
+++ b/.nexus/memory/external-harness-agent-permissions.md
@@ -152,6 +152,12 @@ prompts/<name>.md (frontmatter)
   sandbox_mode + [mcp_servers.nx] disabled_tools
 ```
 
+### nexus-core 히스토리
+
+- **v0.15.x**: `[agents.<id>]` nested 테이블 + `[agents.<id>.mcp_servers.nx] disabled_tools`
+- **v0.16.0**: standalone role file로 전환 시 `[mcp_servers.nx]` 블록을 실수로 drop하고 root-level `disabled_tools` 방출 → codex-cli 0.121의 `RawAgentRoleFileToml` `deny_unknown_fields`에 reject (Issue #48)
+- **v0.16.2**: standalone role file 구조 유지 + `[mcp_servers.nx] disabled_tools = [...]` 복원 (올바른 스키마)
+
 ### Caller 전파 — **De-facto (미문서화)**
 
 Codex 런타임이 MCP `tools/call` 요청의 `_meta` 필드에 `x-codex-turn-metadata` 객체 자동 삽입:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## [0.16.2] - 2026-04-20
+
+### Fixed
+
+- Codex standalone role file(`~/.codex/agents/*.toml`)의 `disabled_tools`가 root-level에 방출되어 codex-cli 0.121+ `RawAgentRoleFileToml`의 `deny_unknown_fields`에 reject되던 문제([#48](https://github.com/moreih29/nexus-core/issues/48)) 수정. `[mcp_servers.nx]` 테이블 블록 하위로 이동해 `RawMcpServerConfig` 정식 필드로 처리. v0.16.0 standalone 전환 시 누락됐던 `[mcp_servers.nx]` 블록 복원.
+
+### Migration Notes
+
+- Codex consumer는 `bun add @moreih29/nexus-core@^0.16.2` 후 sync 재실행 (`nexus sync --harness=codex`). 기존 `~/.codex/agents/*.toml`이 덮어쓰기되어, codex 시작 시 "Ignoring malformed agent role definition" 경고가 사라지는지 확인.
+
+---
+
 ## [0.16.1] - 2026-04-20
 
 ### Fixed

--- a/docs/contract/harness-io.md
+++ b/docs/contract/harness-io.md
@@ -206,10 +206,15 @@ description = "..."
 developer_instructions = """<body>"""
 model = "..."
 sandbox_mode = "..."
-disabled_tools = [...]
+
+[mcp_servers.nx]
+command = "nexus-mcp"
+disabled_tools = ["nx_task_add"]    # 예시 — 실제 항목은 capability-matrix 조합에 따라 다름
 ```
 
-> **주의**: `[agents.<id>]` nested 구조는 `~/.codex/config.toml`(global config)의 agent 정의용이며, standalone role file과 혼용하면 안 된다. standalone 파일에는 반드시 root-level `name`·`developer_instructions` 형식을 사용한다.
+> **주의 1**: `[agents.<id>]` nested 구조는 `~/.codex/config.toml`(global config)의 agent 정의용이며, standalone role file과 혼용하면 안 된다. standalone 파일에는 반드시 root-level `name`·`developer_instructions` 형식을 사용한다.
+
+> **주의 2**: `disabled_tools`는 `[mcp_servers.<id>]` 블록 하위에만 배치한다. root-level에 배치하면 Codex 0.121+ `RawAgentRoleFileToml`의 `deny_unknown_fields`에 걸려 role 전체가 reject된다. `disabled_tools`가 비어 있을 때는 `[mcp_servers.nx]` 블록 자체를 생략한다.
 
 **도메인 서브디렉터리 구조**: Codex 내부 `plugin/`·`agents/`·`install/` 서브디렉터리는 Codex 생태계가 `~/.codex/plugins/`·`~/.codex/agents/`·`~/.codex/config.toml` 3곳에 분리 설치되는 구조를 반영한다. 이 도메인 prefix는 flat 출력 규칙(§4 공통 규칙)과 직교하며 유지된다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Nexus ecosystem authoring layer — canonical agents/skills/hooks and 3-harness build pipeline (Claude Code, OpenCode, Codex)",
   "license": "MIT",
   "type": "module",

--- a/scripts/build-agents.test.ts
+++ b/scripts/build-agents.test.ts
@@ -624,6 +624,33 @@ describe("Scenario 3 — Manifest file content", () => {
     expect(content).toContain("gpt-5.4");
     // No nested table headers
     expect(content).not.toContain("[agents.");
+    // disabled_tools must NOT appear at root level (before any table header)
+    const rootSection = content.split(/^\[/m)[0];
+    expect(rootSection).not.toContain("disabled_tools");
+  });
+
+  test("Codex: agents/<n>.toml emits [mcp_servers.nx] with disabled_tools when capabilities present", () => {
+    const tmp = makeTmp();
+    const assets = [makeAgentEntry()];
+    buildForCodex(assets, capMatrix, invocations, defaultBuildOpts(tmp));
+
+    const tomlPath = join(tmp, "agents", "sample-architect.toml");
+    const content = readFileSync(tomlPath, "utf-8");
+    expect(content).toContain("[mcp_servers.nx]");
+    const afterBlock = content.split("[mcp_servers.nx]")[1];
+    expect(afterBlock).toContain('command = "nexus-mcp"');
+    expect(afterBlock).toContain("disabled_tools = [");
+  });
+
+  test("Codex: agents/<n>.toml omits [mcp_servers.nx] when no disabled_tools", () => {
+    const tmp = makeTmp();
+    const assets = [makeAgentEntry({ frontmatter: { ...makeAgentEntry().frontmatter, capabilities: [] } })];
+    buildForCodex(assets, capMatrix, invocations, defaultBuildOpts(tmp));
+
+    const tomlPath = join(tmp, "agents", "sample-architect.toml");
+    const content = readFileSync(tomlPath, "utf-8");
+    expect(content).not.toContain("[mcp_servers.nx]");
+    expect(content).not.toMatch(/^disabled_tools = /m);
   });
 
   test("OpenCode: opencode.json.fragment is NOT emitted", () => {

--- a/scripts/build-agents.ts
+++ b/scripts/build-agents.ts
@@ -72,6 +72,7 @@ export const CAPABILITY_MATRIX_PATH = join(ROOT, "assets/capability-matrix.yml")
 export const TOOL_NAME_MAP_PATH = join(ROOT, "assets/tools/tool-name-map.yml");
 
 const HARNESSES = ["claude", "opencode", "codex"] as const;
+const CODEX_MCP_NX_COMMAND = "nexus-mcp";
 
 // ---------------------------------------------------------------------------
 // Data shapes
@@ -780,6 +781,9 @@ function codexAgentToml(asset: AssetEntry, capMatrix: CapabilityMatrix, invocati
   if (sandbox_mode) lines.push(`sandbox_mode = ${JSON.stringify(sandbox_mode)}`);
 
   if (disabled_tools.length > 0) {
+    lines.push(``);
+    lines.push(`[mcp_servers.nx]`);
+    lines.push(`command = ${JSON.stringify(CODEX_MCP_NX_COMMAND)}`);
     lines.push(`disabled_tools = [${disabled_tools.map((t) => JSON.stringify(t)).join(", ")}]`);
   }
 
@@ -842,7 +846,7 @@ function codexConfigFragment(agents: AssetEntry[]): string {
     `# Merge this fragment into your codex config.toml`,
     ``,
     `[mcp_servers.nx]`,
-    `command = "nexus-mcp"`,
+    `command = ${JSON.stringify(CODEX_MCP_NX_COMMAND)}`,
     ``,
   ];
 


### PR DESCRIPTION
## Summary

- v0.16.0 Codex standalone role file 전환 시 `[mcp_servers.nx]` 블록을 drop하고 root-level `disabled_tools`만 남긴 버그 수정
- `RawAgentRoleFileToml`의 `deny_unknown_fields`에 걸려 role 전체가 reject되던 문제(#48) 해결
- `[mcp_servers.nx]` 블록(`command = "nexus-mcp"` + `disabled_tools = [...]`)으로 이동 — Codex 0.121 `RawMcpServerConfig` 정식 수용

## Evidence

- Codex commit `b3442f5` (tag `rust-v0.121.0`) 소스 분석:
  - `codex-rs/core/src/config/agent_roles.rs`: `RawAgentRoleFileToml`에만 serde-level `deny_unknown_fields`
  - `codex-rs/config/src/config_toml.rs`: `ConfigToml.mcp_servers: HashMap<String, McpServerConfig>` 존재
  - `codex-rs/config/src/mcp_types.rs`: `RawMcpServerConfig.disabled_tools: Option<Vec<String>>` 정식 필드

## Changes

- `scripts/build-agents.ts`: `CODEX_MCP_NX_COMMAND` 상수 추출, `codexAgentToml()`가 `disabled_tools.length > 0`일 때만 `[mcp_servers.nx]` 블록 emit. `codexConfigFragment()`도 상수 참조.
- `scripts/build-agents.test.ts`: 2건 신규 테스트 (블록 존재 + 빈 경우 생략).
- `docs/contract/harness-io.md`: 스키마 예시 + 경고 박스 2건 업데이트.
- `CHANGELOG.md`: v0.16.2 엔트리.
- `.nexus/memory/external-harness-agent-permissions.md` §4: v0.15.x → v0.16.0(regression) → v0.16.2(복원) 히스토리.
- `package.json`: 0.16.1 → 0.16.2 (SemVer patch).

## Test plan

- [x] \`bun test scripts/build-agents.test.ts\` — 112 pass / 0 fail
- [x] \`bun run build\` — tsc + 3 harness sync 종료 코드 0
- [x] \`dist/codex/agents/architect.toml\` — root-level disabled_tools 부재, \`[mcp_servers.nx]\` + command + disabled_tools 포함
- [x] \`dist/codex/agents/engineer.toml\` — no_task_create만 → \`disabled_tools = ["nx_task_add"]\`
- [x] \`dist/codex/agents/lead.toml\` — capability 없음 → \`[mcp_servers.nx]\` 블록 생략
- [x] Claude/OpenCode 산출물 regression 없음 (disallowedTools / permission 유지)
- [ ] 실제 Codex 0.121에서 "Ignoring malformed agent role definition" 경고 소멸 확인 (merge 후 consumer에서)

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)