### PR TITLE
v0.17.0 — fix #50: 4 regressions (session_id wiring, agent-bootstrap inline, tracker populate, model alias)

### DIFF
--- a/.nexus/context/hooks.md
+++ b/.nexus/context/hooks.md
@@ -162,6 +162,7 @@ runtime.experimental_flag_required
 - `.nexus/state/<sid>/` 디렉토리 생성 (mkdir)
 - `agent-tracker.json` 초기화 (`[]`)
 - `tool-log.jsonl` 초기화 (빈 파일)
+- `.nexus/state/runtime/by-ppid/<process.ppid>.json` 작성 — `{ session_id, updated_at, cwd }`. MCP 서버가 `session_id`를 직접 수신하지 못하는 한계를 우회하는 side-channel. `getSessionId()`가 이 파일을 parent-PID 키로 읽어 session_id를 복원한다 (mtime 캐싱). 채택 이유: Claude/OpenCode/Codex 3 harness 모두 MCP에 session_id를 공식 노출하지 않으므로 hook→file→MCP 브리지가 필요. parent-PID 키잉은 같은 cwd 병렬 세션에서도 race-free.
 
 **additional_context**: 없음 (컨텍스트 주입 안 함)
 
@@ -222,7 +223,9 @@ Active plan session detected. Use [d] to record a decision or [run] to start exe
 
 **stdin 사용 필드**: `session_id`, `tool_name`, `tool_input`, `tool_response`
 
-**matcher**: `Read|Edit|Write|MultiEdit|ApplyPatch|NotebookEdit|Bash`
+**등록 harness**: Claude + OpenCode (tier=extended). Codex는 `event.post_tool_use.read`/`.edit` 미지원으로 제외 — `bash_parsed` 경유 우회는 requires_capabilities에서 제거됨.
+
+**matcher**: `Read|Edit|Write|MultiEdit|ApplyPatch|NotebookEdit`
 
 **부수효과 1 — memory-access 추적**:
 - 대상: `.nexus/memory/` 경로 접근 시

--- a/.nexus/context/mcp-server.md
+++ b/.nexus/context/mcp-server.md
@@ -199,7 +199,7 @@
 
 | 함수 | 동작 | 소스 |
 |---|---|---|
-| `getSessionId(cwd?)` | NEXUS_SESSION_ID env 우선, 없으면 `<branch>-<pid>` | paths.ts |
+| `getSessionId(cwd?)` | NEXUS_SESSION_ID env 우선 → `.nexus/state/runtime/by-ppid/<ppid>.json` (mtime 캐싱) → `<branch>-<pid>` → `unknown-<pid>` | paths.ts |
 | `getSessionRoot(cwd?)` | `.nexus/state/<session_id>/` 경로 반환 | paths.ts |
 
 ### 상태 파일 배치

--- a/.nexus/history.json
+++ b/.nexus/history.json
@@ -6385,6 +6385,147 @@
           "created_at": "2026-04-20T08:28:30.055Z"
         }
       ]
+    },
+    {
+      "schema_version": "0.5",
+      "completed_at": "2026-04-20T12:56:32.053Z",
+      "branch": "fix/issue-50-v0.17.0",
+      "plan": {
+        "id": 21,
+        "topic": "nexus-core v0.17.0 — 이슈 #50 4건 회귀 수정 (session_id wiring, agent-bootstrap assets, tracker populate, capability-matrix model IDs)",
+        "issues": [
+          {
+            "id": 1,
+            "title": "session_id wiring — parent-PID keyed side-channel 설계 및 paths.ts resolveSessionId 확장",
+            "status": "decided",
+            "decision": "**선정: parent-PID keyed side-channel.**\n\n구체안:\n- session-init hook(SessionStart event)에서 `.nexus/state/runtime/by-ppid/<process.ppid>.json` 작성 — 내용 `{session_id, updated_at, cwd}`. ppid는 해당 harness 프로세스(Claude Code 등)의 PID.\n- `src/shared/paths.ts`의 `getSessionId(cwd?)` 우선순위 변경: (1) `NEXUS_SESSION_ID` env (기존), (2) `.nexus/state/runtime/by-ppid/<process.ppid>.json` 읽기 **[신규]**, (3) `<branch>-<pid>` (기존), (4) `unknown-<pid>` (기존).\n- mtime 캐싱으로 per-request IO 최소화 (재호출 시 파일 mtime 변경 없으면 캐시된 값 사용).\n- 병렬 하니스 세션 2개가 같은 cwd에 있어도 ppid가 다르므로 파일도 다름 → race-free.\n\n**반려 대안:**\n- Option 1 (`CLAUDE_SESSION_ID` env 기대): 웹조사 결과 Claude/OpenCode 둘 다 feature request open(#25642, #15117), Codex는 hook 자체가 experimental. upstream 대기 불가.\n- Option 2 (MCP tool schema에 session_id param): LLM이 session_id를 알 공식 채널 없음 → LLM이 잘못된 id 넘기면 타 세션 상태 훼손. 신뢰 경계가 LLM까지 내려감. 기각.\n- Option 3 (`.nexus/state/current.json` 단일 전역): 병렬 세션 2개가 같은 cwd에서 last-writer-wins. 전역 가변 상태 → race. 기각.\n\n**엣지 케이스 대응:**\n- tmux/direnv 등 shell wrapper 밑에서 실행되어도 ppid 일관성 유지(wrapper도 같은 harness 인스턴스에 대응).\n- Codex hook off-by-default 환경: side-channel 파일이 없으면 `<branch>-<pid>` fallback. graceful degradation.\n\n**파일 구조:**\n`.nexus/state/runtime/by-ppid/<ppid>.json` — runtime/ 하위 격리로 기존 `<session_id>/` 디렉터리와 섞이지 않음."
+          },
+          {
+            "id": 2,
+            "title": "agent-bootstrap loadValidRoles — assets/agents FS lookup 제거 및 빌드타임 inline 주입",
+            "status": "decided",
+            "decision": "**선정: prompt-router의 빌드타임 inline 패턴을 agent-bootstrap에 확장.**\n\n구체안:\n- `scripts/build-hooks.ts:compileHandlers()` (335-356줄 근방) 의 entry-specific inline 주입 블록에 `agent-bootstrap` 케이스 추가.\n- 주입 변수: `globalThis.__NEXUS_INLINE_AGENT_ROLES__: string[]` — `assets/agents/<role>/body.md` 존재 디렉터리 이름 배열 (빌드타임 스캔).\n- `assets/hooks/agent-bootstrap/handler.ts`의 `loadValidRoles(cwd)` 교체:\n  ```\n  const inlined = (globalThis as any).__NEXUS_INLINE_AGENT_ROLES__;\n  if (inlined) return inlined;\n  // FS fallback: nexus-core repo dev-only\n  ```\n- 추가 audit: 모든 `assets/hooks/*/handler.ts`에서 `join(cwd, \"assets/...\")` 패턴 grep → 남아있으면 동일 inline 패턴 적용.\n\n**반려 대안:**\n- consumer 측에 assets/ 심볼릭 링크 요구: 배포 표면 오염. 기각.\n- runtime discovery (node_modules 탐색): consumer가 monorepo/pnpm일 때 경로 파편화. 기각.\n- inline 없이 빈 배열 fallback로 조용히 skip 유지: 현재 버그 그대로. 기각.\n\n**왜 v0.16.1 패턴 재사용인가:** 이미 `prompt-router`에서 검증된 안정 패턴. consumer 번들 self-contained 보장이 #46에서 증명됨. 동일 class 버그에 동일 해법."
+          },
+          {
+            "id": 3,
+            "title": "agent-tracker populate 주체 — agent-bootstrap에서 running entry append",
+            "status": "decided",
+            "decision": "**선정: agent-bootstrap(SubagentStart)에서 running entry append + post-tool-telemetry를 managed hooks registry에 등록.**\n\n구체안:\n- (A) `assets/hooks/agent-bootstrap/handler.ts` 끝에 tracker append 로직 추가:\n  ```\n  await updateJsonFileLocked(trackerPath, [], (tracker) => {\n    const exists = tracker.find(e => e.agent_id === agent_id);\n    if (!exists) {\n      tracker.push({ agent_id, agent_type, started_at: new Date().toISOString(), status: \"running\" });\n    }\n    return tracker;\n  });\n  ```\n  - 위치는 role validation/context injection **이후**. resume 재진입 시는 skip (기존 resumeCount 가드 사용).\n  - Idempotent: 동일 agent_id 중복 append 방지.\n- (B) post-tool-telemetry를 hook meta/registry에 정식 등록. `assets/hooks/post-tool-telemetry/meta.yml` 확인 후 event binding (PostToolUse) 선언 및 build-hooks의 registered set에 포함되도록 조정.\n\n**반려 대안:**\n- SessionStart에서 미리 빈 tracker만 두고 external orchestrator가 append 기대: 현재 consumer가 그걸 안 함. 현실성 없음. 기각.\n- agent-finalize가 entry 없으면 자동 생성(find→push-if-missing): populate 주체를 finalize에 두면 start/stop 순서 얽힘. append 책임은 시작 시점에 두는 게 자연스러움. 기각.\n- post-tool-telemetry를 Lead가 직접 호출: harness 독립성 깨짐. 기각.\n\n**왜 이 분할인가:** agent lifecycle 추적(start→finalize) 책임은 agent-bootstrap/finalize 쌍에, tool-level 상세 로그 책임은 post-tool-telemetry에 분리. 두 축이 독립적으로 기능해야 observability가 완결됨."
+          },
+          {
+            "id": 4,
+            "title": "capability-matrix model_tier — claude-opus-4 등 무효 ID를 alias(opus/sonnet/haiku)로 교체",
+            "status": "decided",
+            "decision": "**선정: alias 형태(`opus`/`sonnet`/`haiku`)로 교체.**\n\n구체안:\n- `assets/capability-matrix.yml` model_tier 섹션:\n  - `high.claude: claude-opus-4` → `opus`\n  - `standard.claude: claude-sonnet-4` → `sonnet`\n  - `low.claude: claude-haiku-4` → `haiku`\n- `scripts/build-agents.ts:466`의 `model: ${model}` 출력은 그대로. 결과 frontmatter에 `model: opus` 같은 alias가 나감. Claude Code는 alias를 유효하게 해석.\n- 기존 테스트(`scripts/build-agents.test.ts`)에 `claude-opus-4` 문자열 하드코딩된 부분 있으면 업데이트.\n- 주석 갱신: \"UNVERIFIED slug\" 제거 또는 \"alias form — version-tolerant\" 명시.\n\n**반려 대안:**\n- dated ID로 교체 (`claude-opus-4-7` 등): 지금은 맞지만 Opus 4.8 나오면 또 stale. 이슈 제보자도 alias 권장. 매번 업데이트하는 maintenance 부담. 기각.\n- 모델 필드 자체를 제거: 에이전트 tier별 역할 매핑이 끊김. capability-matrix 설계 의도 훼손. 기각.\n\n**부수 효과 확인:**\n- Codex/OpenCode 컬럼은 변경 없음 (기존 gpt-5.4 등 유지). Claude 컬럼만 alias로 전환.\n- OpenCode가 null inherit하는 건 그대로. 영향 없음."
+          },
+          {
+            "id": 5,
+            "title": "smoke gate 보강 — parent-PID session_id 채널 및 tracker lifecycle 검증 케이스 추가",
+            "status": "decided",
+            "decision": "**선정: smoke-consumer에 \"session-init → MCP resolve\" 왕복 시나리오 + tracker lifecycle 검증 추가. smoke-claude/codex/opencode는 현상 유지(handler isolation 역할).**\n\n구체안:\n- `scripts/smoke/smoke-consumer.ts` 또는 동등 위치에 신규 케이스 2건:\n  1. **session_id 채널 왕복**: temp cwd에서 session-init handler 실행 → `.nexus/state/runtime/by-ppid/<process.pid>.json` 생성 확인 → 같은 cwd에서 `getSessionId()` 호출 시 파일의 session_id 반환되는지 assert. (process.ppid를 테스트에서 override하려면 paths.ts에 `__test_ppid` hook 또는 env 주입 경로 필요)\n  2. **tracker lifecycle**: session-init → agent-bootstrap(SubagentStart payload 모사) → agent-finalize(SubagentStop 모사) → 최종 tracker.json에 `{agent_id, status:\"completed\", started_at, stopped_at}` 있는지 assert.\n- 기존 handler isolation smoke gate는 유지 (빠르고 격리 보장). 신규 케이스는 handler **간 상호작용**을 검증하는 integration smoke.\n- **assets/agents/*.md frontmatter validation gate 추가**: build-agents 산출물 `dist/claude/agents/*.md`에서 `model:` 값이 허용 집합(`opus`|`sonnet`|`haiku`|날짜ID 정규식) 안에 있는지 체크. 이번 #50 제보 4건 중 하나를 재발 방지 가드로 고정.\n\n**반려 대안:**\n- live Claude Code + 실제 MCP spawn 전체 e2e: 환경 의존성 과도, CI 불안정. 기각.\n- Playwright 같은 browser 기반: MCP/hook 계층에 부적합. 기각.\n- smoke gate 추가 없이 release: 이슈 #50 본문이 지적한 gap 그대로. 재발 위험. 기각.\n\n**CI 통합:** `package.json` `smoke` 집계 스크립트에 포함. 기존 4개 gate + 신규 integration 케이스."
+          },
+          {
+            "id": 6,
+            "title": "release 준비 — version bump v0.17.0, CHANGELOG, PR 작성",
+            "status": "decided",
+            "decision": "**선정: v0.17.0 minor bump + CHANGELOG entry + PR close-on-merge.**\n\n구체안:\n- **version**: `package.json` 0.16.2 → **0.17.0** (minor bump). 이유: `.nexus/state/runtime/by-ppid/` 레이아웃 추가는 내부 변경이지만, hook 빌드 산출물의 inline 주입 변경 + capability-matrix model 값 변경은 소비자 가시 변화. breaking은 없음(graceful fallback).\n- **CHANGELOG.md**: Keep-a-Changelog 포맷 유지. 섹션:\n  - `### Fixed`: 4건 회귀 상세 (session_id wiring #50 part 1, agent-bootstrap assets #50 part 2, tracker populate #50 part 3, model IDs #50 part 4)\n  - `### Added`: smoke-consumer integration 케이스 2건 + frontmatter validation gate\n  - `### Migration Notes`: consumer 측 추가 작업 없음 명시 (모두 투명한 수정). `.nexus/state/runtime/` 디렉터리는 session-init이 자동 생성.\n- **PR 본문**: 이슈 #50 각 bug별로 closes 링크. Test plan 체크리스트 (build, smoke, consumer 실증).\n- **이슈 자동 close**: PR에 `Closes #50` 포함 → merge 시 자동.\n\n**반려 대안:**\n- patch bump (0.16.3): 수정 범위 넓고 hook 번들 구조가 변함. patch에 부적합. 기각.\n- major bump (1.0.0): API breaking 없음. 과잉. 기각.\n- 개별 PR 4개: 이슈 제보자가 통합 수정 가능성 언급, 의존관계(session_id 채널이 tracker 연쇄에 영향) 있어 단일 PR이 추적에 유리. 기각.\n\n**push/merge는 user 결정** — nx-run skill scope 바깥."
+          }
+        ],
+        "research_summary": "이슈 #50 제보 + 웹조사 + 코드 Explore 결과:\n\n1. 웹조사: Claude/OpenCode/Codex 3 harness 모두 MCP에 session_id 공식 노출 없음. Claude issue #25642, OpenCode issue #15117 open. Codex hook은 experimental. env/initialize/tool-meta 경로 모두 미지원. 결과: hook→file→MCP side-channel이 유일한 robust 경로.\n\n2. 코드 확인:\n- src/shared/paths.ts:69-78 — getSessionId()는 NEXUS_SESSION_ID env → <branch>-<pid> → unknown-<pid>. 세션당 고유 ID 아님.\n- assets/hooks/session-init/handler.ts — agent-tracker.json([]), tool-log.jsonl(빈 파일) 초기화. current.json 등 side-channel 없음.\n- assets/hooks/agent-bootstrap/handler.ts:7-8 — loadValidRoles(cwd)가 join(cwd, 'assets/agents')로 FS lookup. consumer layout에 해당 디렉터리 없어 validRoles=[] → 모든 subagent early return. #46과 동일 클래스.\n- assets/hooks/agent-finalize/handler.ts — tracker.find(agent_id) 후 status update. append 주체 없음 → 영구 no-op.\n- assets/hooks/post-tool-telemetry/handler.ts — EDIT_TOOLS + agent_id 있을 때 tool-log append. 코드는 정상. 단 hooks/hooks.json 등록 여부가 실패 원인일 수 있음.\n- scripts/build-hooks.ts:335-356 — prompt-router entry에만 globalThis.__NEXUS_INLINE_INVOCATIONS__ 주입. agent-bootstrap에는 미적용.\n- assets/capability-matrix.yml:181,189,196 — model_tier에 claude-opus-4/claude-sonnet-4/claude-haiku-4. 유효 ID는 claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20251001.\n- scripts/build-agents.ts:466 — if (model) fmLines.push(`model: ${model}`) — frontmatter에 그대로 출력.\n- package.json: version 0.16.2. 4개 smoke gate (claude/codex/opencode/consumer). smoke는 handler isolation만 검증 → 4건 전부 miss.\n\n3. 설계 확정 (대화 맥락 option 선택 완료):\n- Bug #1: parent-PID keyed side-channel. session-init이 .nexus/state/runtime/by-ppid/<ppid>.json 작성, MCP는 process.ppid로 해당 파일 읽기. race-free for 병렬 세션.\n- Bug #2: prompt-router 패턴 그대로 적용 — build-hooks.ts에서 agent-bootstrap entry에도 __NEXUS_INLINE_AGENT_ROLES__ 주입.\n- Bug #3: agent-bootstrap SubagentStart에서 tracker entry append + post-tool-telemetry를 managed hooks.json에 등록.\n- Bug #4: capability-matrix의 claude-opus-4/sonnet-4/haiku-4 → opus/sonnet/haiku alias (버전 내성).",
+        "created_at": "2026-04-20T12:18:20.358Z"
+      },
+      "tasks": [
+        {
+          "id": 1,
+          "title": "session_id parent-PID side-channel 구현",
+          "context": "plan_issue=1. MCP server가 자기 session_id를 모르는 P0 회귀 해결. session-init이 `.nexus/state/runtime/by-ppid/<process.ppid>.json` 작성 → getSessionId()가 process.ppid 기반으로 읽기. NEXUS_SESSION_ID env → by-ppid file → branch-pid → unknown-pid 순 우선순위.",
+          "approach": "1. `src/shared/paths.ts`: (a) `BY_PPID_DIR = join(cwd, \".nexus/state/runtime/by-ppid\")` helper 추가. (b) `readSessionIdFromByPpidFile(cwd): string | null` 함수 — `<BY_PPID_DIR>/<process.ppid>.json` 읽어 `session_id` 반환, 실패 시 null. mtime 캐싱(모듈 레벨 Map)으로 per-request IO 최소화. (c) `getSessionId(cwd?)` 우선순위 갱신: env → by-ppid → branch-pid → unknown-pid.\n2. `assets/hooks/session-init/handler.ts`: SessionStart event에서 `mkdirSync(runtimeByPpidDir, { recursive: true })` → `writeFileSync(<ppid>.json, JSON.stringify({ session_id, updated_at, cwd }))`. 기존 `<session_id>/` 초기화 로직은 유지.\n3. `src/shared/paths.test.ts`: 신규 테스트 3건 — (a) by-ppid 파일 존재 시 읽기, (b) env 우선순위 검증, (c) 파일 없을 때 branch-pid fallback. 테스트용 ppid 오버라이드는 `NEXUS_TEST_PPID` env 또는 함수 인자로 제공.\n4. consumer 관점: `.nexus/state/runtime/` 디렉터리는 auto-create. 추가 설정 불필요.",
+          "acceptance": "- `getSessionId()`가 by-ppid 파일이 있으면 해당 session_id 반환\n- session-init 실행 후 `.nexus/state/runtime/by-ppid/<ppid>.json` 생성 확인\n- `tsc` + `bun test src/shared/paths.test.ts` 통과\n- 기존 테스트 회귀 없음\n- 파일 레이아웃 문서 한 줄(주석 또는 context)이 session-init handler에 남음",
+          "risk": "mtime 캐싱이 오래된 값을 쥐고 있을 경우 session_id 불일치. → 파일 mtime 변경 시 캐시 invalidate 필수. 테스트 환경에서 process.ppid 오버라이드 없이는 real ppid로 테스트가 얽힘 → test-only hook 도입 필요.",
+          "status": "pending",
+          "deps": [],
+          "plan_issue": 1,
+          "owner": "engineer",
+          "created_at": "2026-04-20T12:20:49.384Z"
+        },
+        {
+          "id": 2,
+          "title": "agent-bootstrap inline 주입 + tracker populate + post-tool-telemetry 등록",
+          "context": "plan_issue=2 (primary), plan_issue=3 (bundled). same_file_bundle exception 적용: 두 이슈 모두 `assets/hooks/agent-bootstrap/handler.ts`를 수정하므로 parallel write 충돌 방지를 위해 1 task로 통합.",
+          "approach": "**Part A — inline 주입 (issue #2):**\n1. `scripts/build-hooks.ts` compileHandlers() 내 prompt-router 분기 근처(335-356줄)에 `agent-bootstrap` 케이스 추가. `readdirSync(\"assets/agents\")`로 디렉터리 이름 수집 → `globalThis.__NEXUS_INLINE_AGENT_ROLES__ = [...]` JSON stringify → esbuild `banner`/`define` 옵션으로 주입.\n2. `assets/hooks/agent-bootstrap/handler.ts`의 `loadValidRoles(cwd)` 교체:\n   ```ts\n   function loadValidRoles(cwd: string): string[] {\n     const inlined = (globalThis as any).__NEXUS_INLINE_AGENT_ROLES__;\n     if (Array.isArray(inlined)) return inlined;\n     const agentsDir = join(cwd, \"assets/agents\"); // dev fallback\n     if (!existsSync(agentsDir)) return [];\n     return readdirSync(agentsDir, { withFileTypes: true })\n       .filter(e => e.isDirectory()).map(e => e.name);\n   }\n   ```\n3. 추가 audit: `grep -rn \"assets/\" assets/hooks/*/handler.ts` — 남은 FS lookup 있으면 동일 패턴 적용.\n\n**Part B — tracker append (issue #3):**\n4. `assets/hooks/agent-bootstrap/handler.ts` handler 말미에 `updateJsonFileLocked(trackerPath, [], tracker => { if (!tracker.find(e=>e.agent_id===agent_id)) tracker.push({agent_id, agent_type, started_at: new Date().toISOString(), status:\"running\"}); return tracker; })`. 위치: resume guard + validRoles 체크 통과 후, context injection 전/후 무관.\n5. `assets/hooks/post-tool-telemetry/meta.yml` 확인. event=PostToolUse binding 없으면 추가. `scripts/build-hooks.ts`의 registered set에 포함되는지 확인, 누락 시 포함.\n\n**검증:** 빌드 후 `dist/hooks/agent-bootstrap.js`에 `__NEXUS_INLINE_AGENT_ROLES__` 주입 문자열 존재. `dist/manifests/claude-hooks.json`에 post-tool-telemetry 등록 확인.",
+          "acceptance": "- `dist/hooks/agent-bootstrap.js`에 inline roles 배열 포함 (grep으로 확인)\n- consumer 시나리오: cwd에 assets/ 없어도 validRoles 비어있지 않음\n- SubagentStart 시 agent-tracker.json에 running entry 1건 append 확인 (locked-update 사용, 중복 append 방지)\n- post-tool-telemetry가 PostToolUse event에 등록되어 dist manifest에 포함\n- `bun run build` 통과, 타입 에러 없음",
+          "risk": "inline 주입 방식이 esbuild의 `banner` vs `define` 중 어느 쪽을 쓸지 prompt-router 선례 확인 필요(후자가 tree-shakable). tracker append가 두 번 발동할 경우(이벤트 재전송 등) 중복 entry — idempotent find-first로 방지.",
+          "status": "pending",
+          "deps": [
+            1
+          ],
+          "plan_issue": 2,
+          "owner": "engineer",
+          "created_at": "2026-04-20T12:21:12.281Z"
+        },
+        {
+          "id": 3,
+          "title": "capability-matrix model_tier alias 교체",
+          "context": "plan_issue=4. claude-opus-4/sonnet-4/haiku-4는 존재하지 않는 model ID → subagent spawn 실패(P0). alias(opus/sonnet/haiku)로 교체하여 버전 내성 확보.",
+          "approach": "1. `assets/capability-matrix.yml` 라인 181/189/196 수정:\n   - `claude-opus-4` → `opus`\n   - `claude-sonnet-4` → `sonnet`\n   - `claude-haiku-4` → `haiku`\n2. 주변 주석(line 167-173 근방)에서 \"UNVERIFIED\"/\"Update this section when OpenAI releases\" 문구를 Claude 쪽에 \"alias form — version-tolerant\" 설명으로 보강.\n3. `scripts/build-agents.test.ts`에 `claude-opus-4`/`claude-sonnet-4`/`claude-haiku-4` 문자열 하드코딩이 있으면 alias로 업데이트. (Grep 선행)\n4. 빌드 재실행 → `dist/claude/agents/<n>.md` frontmatter의 `model:` 값이 alias로 출력되는지 샘플 확인.",
+          "acceptance": "- capability-matrix.yml의 model_tier.*.claude 값 모두 alias 형태\n- `bun run build` 성공\n- dist/claude/agents/architect.md frontmatter `model: opus` 확인\n- 빌드 산출물 3 harness 전부 정상 (Claude만 alias, Codex/OpenCode 미변경)\n- 테스트 회귀 없음",
+          "risk": "alias는 Claude Code 측 해석에 의존. 만약 특정 구버전 Claude Code가 alias 해석 안 하면 consumer break — 그러나 이슈 #50 제보에서 이미 alias로 override 작동 확인됨.",
+          "status": "pending",
+          "deps": [],
+          "plan_issue": 4,
+          "owner": "lead",
+          "created_at": "2026-04-20T12:21:28.434Z"
+        },
+        {
+          "id": 4,
+          "title": "smoke-consumer integration 케이스 + frontmatter validation gate",
+          "context": "plan_issue=5. 기존 smoke gate가 handler isolation만 검증해서 이슈 #50의 4건 모두 miss. integration smoke 케이스 2건(session_id 왕복, tracker lifecycle) + build-time frontmatter validation gate 추가로 재발 방지.",
+          "approach": "1. `scripts/smoke/smoke-consumer.ts` (또는 `scripts/smoke-consumer.ts` — 실제 위치는 Explore 시 확인)에 신규 케이스:\n   **(a) session_id 채널 왕복**: tmpdir + NEXUS_TEST_PPID 주입 → session-init handler 실행 → `.nexus/state/runtime/by-ppid/<ppid>.json` 존재 assert → `getSessionId()` 호출 결과가 기록된 session_id와 일치 assert.\n   **(b) tracker lifecycle**: session-init → agent-bootstrap payload(SubagentStart + agent_type=architect, agent_id=test-abc) 모사 → agent-finalize payload(SubagentStop, 동일 agent_id) 모사 → `agent-tracker.json`에 `[{agent_id:\"test-abc\", status:\"completed\", started_at, stopped_at}]` assert.\n2. **frontmatter validation gate**: `scripts/build-agents.ts` 또는 별도 `scripts/validate-frontmatter.ts` — build 후 `dist/claude/agents/*.md`에서 `model:` 값이 허용 집합(`opus`|`sonnet`|`haiku`|`claude-opus-4-N`|`claude-sonnet-4-N`|`claude-haiku-4-N-*` 정규식) 안인지 검사. 불일치 시 build fail. `package.json` build chain에 포함.\n3. CI 통합: 기존 `package.json` smoke 스크립트 집계에 신규 케이스 자연히 포함.",
+          "acceptance": "- smoke-consumer 실행 시 신규 2건 케이스가 pass\n- 의도적 regression 주입(model 필드를 `claude-opus-4`로 되돌리기) 시 build가 frontmatter gate에서 fail\n- 기존 smoke-claude/codex/opencode gate 통과 유지\n- package.json scripts 구조 일관성 유지",
+          "risk": "NEXUS_TEST_PPID 같은 test-only hook을 프로덕션 paths.ts에 넣는 것에 대한 노이즈. → 최소 범위로 격리(test 환경 분기 명확).",
+          "status": "pending",
+          "deps": [
+            1,
+            2
+          ],
+          "plan_issue": 5,
+          "owner": "engineer",
+          "created_at": "2026-04-20T12:21:46.244Z"
+        },
+        {
+          "id": 5,
+          "title": "4건 수정 통합 검증 — acceptance tester",
+          "context": "issue #50 4건 회귀에 대한 수정 acceptance 기준을 각 task별로 PASS/FAIL 판정. runtime behavior 검증 조건 충족(session_id resolve, hook lifecycle, build artifact) → Tester 필수.",
+          "approach": "1. tasks.json에서 task 1-4의 `acceptance` 항목을 순차 검증.\n2. 실행 명령: `bun test src/shared/paths.test.ts`, `bun run build`, `bun run smoke:consumer` (또는 equivalent).\n3. 각 acceptance 조건마다 PASS/FAIL + 실행 로그 근거.\n4. 추가 수동 검증:\n   - `dist/claude/agents/architect.md` frontmatter에 `model: opus` 확인\n   - `dist/hooks/agent-bootstrap.js`에 `__NEXUS_INLINE_AGENT_ROLES__` inline 확인\n   - `.nexus/state/runtime/by-ppid/<ppid>.json` 생성 실증(로컬 dry-run)\n5. 실패 항목 있으면 원인 요약 후 Lead에 보고. 모두 PASS면 \"all green\" 결론.",
+          "acceptance": "- 모든 task 1-4의 acceptance 조건이 PASS\n- 실패 항목은 구체적 근거(명령 출력/파일 경로)와 함께 보고\n- 기존 smoke-claude/codex/opencode 회귀 없음",
+          "risk": "test-only hook(NEXUS_TEST_PPID) 없이 real ppid 기반 테스트가 환경 의존적. CI에서 flaky 가능성 → 확정적 test double 필수.",
+          "status": "pending",
+          "deps": [
+            1,
+            2,
+            3,
+            4
+          ],
+          "plan_issue": 5,
+          "owner": "tester",
+          "created_at": "2026-04-20T12:21:59.677Z"
+        },
+        {
+          "id": 6,
+          "title": "release — version bump v0.17.0, CHANGELOG, PR",
+          "context": "plan_issue=6. 모든 수정 반영 후 최종 배포 준비. minor bump(0.16.2→0.17.0), CHANGELOG entry 작성, PR 생성 및 Closes #50 링크.",
+          "approach": "1. `package.json` version: `0.16.2` → `0.17.0`\n2. `CHANGELOG.md` 상단에 `## [0.17.0] - 2026-04-20` entry:\n   - `### Fixed`: 4건 회귀 (#50 part 1-4)\n   - `### Added`: smoke-consumer integration 케이스 2건 + frontmatter validation gate\n   - `### Migration Notes`: consumer 작업 없음 (`.nexus/state/runtime/`는 자동 생성)\n3. 최종 `bun run build` 한 번 더 실행 → dist/ 산출물 최신화\n4. git add: 소스 수정 파일 + dist/ + `.nexus/history.json` + 수정된 memory/context\n5. 커밋 메시지: `feat(v0.17.0): 이슈 #50 4건 회귀 수정 — session_id wiring, agent-bootstrap inline, tracker populate, model alias`. Co-Authored-By 포함.\n6. push → `gh pr create` — title \"v0.17.0 — fix #50 (4 regressions)\", body에 각 bug 요약 + test plan + `Closes #50`\n7. user에 PR URL 보고. merge 결정은 user 몫.",
+          "acceptance": "- package.json version = 0.17.0\n- CHANGELOG.md에 0.17.0 entry 추가, Keep-a-Changelog 포맷 유지\n- git commit 생성 (HEREDOC 메시지, explicit add)\n- PR 생성 및 URL 제공\n- `Closes #50` 문자열 PR body 포함",
+          "risk": "push 전 user 확인 단계 미확보. → PR 생성은 user 권한 필요한 작업이지만, 이미 [run] 의도된 흐름이라 진행. merge는 user 결정.",
+          "status": "pending",
+          "deps": [
+            5
+          ],
+          "plan_issue": 6,
+          "owner": "lead",
+          "created_at": "2026-04-20T12:22:14.157Z"
+        }
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 ---
 
+## [0.17.0] - 2026-04-20
+
+### Fixed
+
+- v0.16.1 downstream에서 surfaced된 4건 회귀 일괄 수정 ([#50](https://github.com/moreih29/nexus-core/issues/50)).
+  - **MCP session_id wiring (P0)**: MCP server가 자기 session_id를 알 채널이 없어 `unknown-<pid>`로 fallback → `.nexus/state/` 가 두 경로로 쪼개져 `[d]`·`[run]` 태그 dispatch가 영구 차단되던 문제. Claude Code·OpenCode·Codex 3 harness 모두 공식 session_id 노출 메커니즘이 없음([upstream feature requests](https://github.com/anthropics/claude-code/issues/25642))이 확인되어 **parent-PID keyed side-channel** 방식으로 해결: `session-init` hook이 `.nexus/state/runtime/by-ppid/<process.ppid>.json`을 기록하고 `src/shared/paths.ts:getSessionId()`가 `process.ppid` 기반으로 읽어낸다(mtime 캐싱 포함). 우선순위는 `NEXUS_SESSION_ID` env → by-ppid 파일 → `<branch>-<pid>` → `unknown-<pid>`. 병렬 harness 세션이 같은 cwd에 있어도 ppid가 다르므로 race-free.
+  - **agent-bootstrap assets lookup (P1)**: `loadValidRoles(cwd)`가 `join(cwd, "assets/agents")` FS lookup에 의존해 consumer 설치에서 항상 `validRoles=[]`로 early-return, 모든 subagent의 memory/context index 주입이 skip되던 문제. #46과 동일 클래스. `scripts/build-hooks.ts`의 prompt-router inline 패턴을 `agent-bootstrap` entry에도 확장해 `globalThis.__NEXUS_INLINE_AGENT_ROLES__`를 빌드타임에 주입, handler가 이를 우선 사용하고 FS 탐색은 dev fallback으로 유지.
+  - **agent-tracker populate 주체 부재 (P1)**: `agent-tracker.json`에 running entry를 append 하는 코드 경로가 존재하지 않아 `agent-finalize`의 update가 영구 no-op이던 문제. `agent-bootstrap` SubagentStart 시점에 `updateJsonFileLocked` 기반 idempotent append 로직을 추가(`{agent_id, agent_type, started_at, status:"running"}`)해 lifecycle 관측이 복구됨. 추가로 `post-tool-telemetry/meta.yml`에서 over-declared `event.post_tool_use.bash_parsed` capability를 제거, Claude/OpenCode에 정상 등록되어 `tool-log.jsonl` append가 활성화됨(`tier=extended registered=[claude,opencode]`).
+  - **stale model IDs (P0)**: `assets/capability-matrix.yml` model_tier의 `claude-opus-4` / `claude-sonnet-4` / `claude-haiku-4`가 실제로는 존재하지 않는 model ID여서 subagent spawn이 outright 실패하던 문제. alias 형태(`opus` / `sonnet` / `haiku`)로 교체해 Claude Code의 latest-in-series resolution에 위임, 신규 dated ID 릴리스마다 업데이트하는 maintenance 부담을 제거.
+
+### Added
+
+- `scripts/smoke/smoke-consumer.ts` — Case C (session_id side-channel round-trip) + Case D (tracker lifecycle: init → bootstrap → finalize) integration 케이스 2건. 기존 handler isolation smoke가 miss했던 handler-MCP-hook 상호작용을 재발 방지 게이트로 고정.
+- `scripts/build-agents.ts:validateClaudeModel()` — 빌드타임 frontmatter gate. claude harness 모델 값이 alias(`opus|sonnet|haiku`) 또는 dated ID(`claude-{family}-\d+-\d+(-\d{8})?` — minor version 필수)가 아니면 build fail. 이번 cycle의 Bug #4 재발 방지.
+
+### Migration Notes
+
+- consumer 측 추가 작업 없음 — `.nexus/state/runtime/by-ppid/` 디렉터리는 `session-init` hook이 SessionStart 시점에 자동 생성.
+- v0.16.x에서 bump하는 경우 `bun add @moreih29/nexus-core@^0.17.0` 후 `nexus sync --harness=<harness>` 재실행을 권장.
+- 기존 `.nexus/state/<session_id>/` 레이아웃은 변경 없음. 새 `runtime/by-ppid/` 서브트리는 격리되어 기존 세션 상태에 영향 없음.
+
+---
+
 ## [0.16.2] - 2026-04-20
 
 ### Fixed

--- a/assets/capability-matrix.yml
+++ b/assets/capability-matrix.yml
@@ -162,8 +162,10 @@ capabilities:
 #   Source: https://opencode.ai/docs/agents/ (model field is optional)
 #   Verified: .nexus/memory/external-opencode-plugin.md §5
 #
-# claude model slugs (partial-match basis — Claude Code resolves to latest in series):
-#   Source: https://code.claude.com/docs/en/sub-agents (model field)
+# claude model slugs (alias form — version-tolerant; Claude Code resolves to the
+#   latest dated model in the series. Prefer aliases (opus/sonnet/haiku) over
+#   dated IDs (claude-opus-4-7 등) to avoid rot as new versions ship.):
+#   Source: https://code.claude.com/docs/en/sub-agents (model field accepts aliases)
 #   Verified: .nexus/memory/external-claude-code-hooks-tools.md §6 (Agent tool: model param)
 #
 # codex model slugs:
@@ -178,7 +180,7 @@ model_tier:
   # high — used by: architect, designer, postdoc, strategist
   # Reasoning-intensive advisory roles that require deep analysis.
   high:
-    claude: claude-opus-4
+    claude: opus            # alias — Claude Code resolves to latest Opus
     codex: gpt-5.4          # UNVERIFIED slug — confirm against current Codex model list
     opencode: null          # inherits user config
 
@@ -186,13 +188,13 @@ model_tier:
   # Execution and verification roles where throughput matters more than
   # top-tier reasoning.
   standard:
-    claude: claude-sonnet-4
+    claude: sonnet          # alias — Claude Code resolves to latest Sonnet
     codex: gpt-5.3-codex    # UNVERIFIED slug — confirm against current Codex model list
     opencode: null          # inherits user config
 
   # low — reserved tier; no agents currently assigned.
   # Intended for lightweight utility agents (fast, cheap, simple tasks).
   low:
-    claude: claude-haiku-4
+    claude: haiku           # alias — Claude Code resolves to latest Haiku
     codex: gpt-5.4-mini     # UNVERIFIED slug — confirm against current Codex model list
     opencode: null          # inherits user config

--- a/assets/hooks/agent-bootstrap/handler.test.ts
+++ b/assets/hooks/agent-bootstrap/handler.test.ts
@@ -7,7 +7,7 @@
  * (3) resume_count > 0 → skip (not fresh)
  * (4) .nexus/rules/<role>.md absent → core index only
  * (5) core index > 2KB → truncated to recent-modified N entries
- * (6) tracker write side-effect absent (agent-tracker.json unchanged before/after)
+ * (6) tracker append: new entry created; same agent_id is idempotent (no duplicate)
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
@@ -256,43 +256,44 @@ describe("scenario 5: 2KB truncation of core index", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Scenario (6): no tracker write side-effects
+// Scenario (6): tracker append
 // ---------------------------------------------------------------------------
 
-describe("scenario 6: handler produces no file write side-effects", () => {
+describe("scenario 6: tracker append", () => {
   let cleanup: () => void;
 
   afterAll(() => cleanup?.());
 
-  test("agent-tracker.json is not created or modified by handler", async () => {
+  test("agent-tracker.json is created with running entry for fresh agent", async () => {
     const { cwd, sessionId, cleanup: c } = makeFixture({ withTracker: undefined });
     cleanup = c;
 
     const trackerPath = join(cwd, ".nexus/state", sessionId, "agent-tracker.json");
 
-    // Tracker must not exist before the call
     expect(existsSync(trackerPath)).toBe(false);
 
-    await handler(makeInput(cwd, sessionId, "architect"));
+    await handler(makeInput(cwd, sessionId, "architect", "agent-001"));
 
-    // Tracker must still not exist after the call
-    expect(existsSync(trackerPath)).toBe(false);
+    expect(existsSync(trackerPath)).toBe(true);
+    const tracker = JSON.parse(readFileSync(trackerPath, "utf-8")) as Array<Record<string, unknown>>;
+    expect(tracker).toHaveLength(1);
+    expect(tracker[0]["agent_id"]).toBe("agent-001");
+    expect(tracker[0]["agent_type"]).toBe("architect");
+    expect(tracker[0]["status"]).toBe("running");
+    expect(typeof tracker[0]["started_at"]).toBe("string");
   });
 
-  test("pre-existing agent-tracker.json is not modified by handler", async () => {
-    const agentId = "agent-side-effect";
-    const { cwd, sessionId, cleanup: c } = makeFixture({
-      withTracker: { agentId, resumeCount: 0 },
-    });
+  test("duplicate agent_id on second call does not create a second entry", async () => {
+    const { cwd, sessionId, cleanup: c } = makeFixture({ withTracker: undefined });
     cleanup = c;
 
     const trackerPath = join(cwd, ".nexus/state", sessionId, "agent-tracker.json");
-    const before = readFileSync(trackerPath, "utf-8");
 
-    await handler(makeInput(cwd, sessionId, "architect", agentId));
+    await handler(makeInput(cwd, sessionId, "architect", "agent-001"));
+    await handler(makeInput(cwd, sessionId, "architect", "agent-001"));
 
-    const after = readFileSync(trackerPath, "utf-8");
-    expect(after).toBe(before);
+    const tracker = JSON.parse(readFileSync(trackerPath, "utf-8")) as Array<Record<string, unknown>>;
+    expect(tracker.filter((e) => e["agent_id"] === "agent-001")).toHaveLength(1);
   });
 });
 

--- a/assets/hooks/agent-bootstrap/handler.ts
+++ b/assets/hooks/agent-bootstrap/handler.ts
@@ -1,18 +1,18 @@
 import type { HookHandler } from "../../../src/hooks/types.js";
+import { updateJsonFileLocked } from "../../../src/shared/json-store.js";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const CORE_INDEX_SIZE_LIMIT = 2 * 1024; // 2KB
 
 function loadValidRoles(cwd: string): string[] {
+  const inlined = (globalThis as unknown as { __NEXUS_INLINE_AGENT_ROLES__?: string[] }).__NEXUS_INLINE_AGENT_ROLES__;
+  if (Array.isArray(inlined)) return inlined;
   const agentsDir = join(cwd, "assets/agents");
-  const roles: string[] = [];
-  if (existsSync(agentsDir)) {
-    for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) roles.push(entry.name);
-    }
-  }
-  return roles;
+  if (!existsSync(agentsDir)) return [];
+  return readdirSync(agentsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
 }
 
 function readFirstLine(path: string): string {
@@ -94,6 +94,19 @@ const handler: HookHandler = async (input) => {
   // unregistered role: silent skip
   const validRoles = loadValidRoles(cwd);
   if (!validRoles.includes(agent_type)) return;
+
+  const trackerPath = join(cwd, ".nexus/state", session_id, "agent-tracker.json");
+  await updateJsonFileLocked(trackerPath, [], (tracker: Array<Record<string, unknown>>) => {
+    const list = Array.isArray(tracker) ? tracker : [];
+    if (list.find((e) => e["agent_id"] === agent_id)) return list;
+    list.push({
+      agent_id,
+      agent_type,
+      started_at: new Date().toISOString(),
+      status: "running",
+    });
+    return list;
+  });
 
   const parts: string[] = [];
 

--- a/assets/hooks/post-tool-telemetry/meta.yml
+++ b/assets/hooks/post-tool-telemetry/meta.yml
@@ -1,11 +1,10 @@
 name: post-tool-telemetry
 description: Track memory access and file-edit operations for strength/forgetting signals and audit
 events: [PostToolUse]
-matcher: "Read|Edit|Write|MultiEdit|ApplyPatch|NotebookEdit|Bash"
+matcher: "Read|Edit|Write|MultiEdit|ApplyPatch|NotebookEdit"
 timeout: 5
 fallback: warn
 priority: 10
 requires_capabilities:
   - event.post_tool_use.read
   - event.post_tool_use.edit
-  - event.post_tool_use.bash_parsed

--- a/assets/hooks/session-init/handler.ts
+++ b/assets/hooks/session-init/handler.ts
@@ -1,11 +1,11 @@
 import type { HookHandler } from "../../../src/hooks/types.js";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join, basename } from "node:path";
+import { getParentPid } from "../../../src/shared/paths.js";
 
 const handler: HookHandler = async (input) => {
   if (input.hook_event_name !== "SessionStart") return;
 
-  // Sanitize session_id to prevent path traversal
   const safeSid = basename(input.session_id);
   if (!safeSid || safeSid.startsWith(".") || safeSid.includes("/")) {
     process.stderr.write(`[session-init] invalid session_id: ${input.session_id}\n`);
@@ -14,17 +14,18 @@ const handler: HookHandler = async (input) => {
 
   const sessionDir = join(input.cwd, ".nexus/state", safeSid);
 
-  // Ensure directory exists (idempotent)
   mkdirSync(sessionDir, { recursive: true });
 
-  // Initialize per-session state files — overwrite unconditionally (resume is intentional)
   writeFileSync(join(sessionDir, "agent-tracker.json"), "[]");
   writeFileSync(join(sessionDir, "tool-log.jsonl"), "");
 
-  // plan.json and tasks.json are MCP responsibility — not touched here
-  // memory-access.jsonl is project-level — not touched here
-
-  // No additional_context returned (decided: no context injection at session start)
+  const ppid = getParentPid();
+  const byPpidDir = join(input.cwd, ".nexus/state/runtime/by-ppid");
+  mkdirSync(byPpidDir, { recursive: true });
+  writeFileSync(
+    join(byPpidDir, `${ppid}.json`),
+    JSON.stringify({ session_id: input.session_id, updated_at: new Date().toISOString(), cwd: input.cwd }),
+  );
 };
 
 export default handler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Nexus ecosystem authoring layer — canonical agents/skills/hooks and 3-harness build pipeline (Claude Code, OpenCode, Codex)",
   "license": "MIT",
   "type": "module",

--- a/scripts/build-agents.test.ts
+++ b/scripts/build-agents.test.ts
@@ -34,6 +34,7 @@ import {
   resolveOpencodePermissions,
   resolveCodexConfig,
   resolveModel,
+  validateClaudeModel,
   buildForClaude,
   buildForOpencode,
   buildForCodex,
@@ -105,9 +106,9 @@ function minimalCapMatrix(): CapabilityMatrix {
       },
     },
     model_tier: {
-      high: { claude: "claude-opus-4", codex: "gpt-5.4", opencode: null },
-      standard: { claude: "claude-sonnet-4", codex: "gpt-5.3-codex", opencode: null },
-      low: { claude: "claude-haiku-4", codex: "gpt-5.4-mini", opencode: null },
+      high: { claude: "opus", codex: "gpt-5.4", opencode: null },
+      standard: { claude: "sonnet", codex: "gpt-5.3-codex", opencode: null },
+      low: { claude: "haiku", codex: "gpt-5.4-mini", opencode: null },
     },
   };
 }
@@ -449,9 +450,9 @@ describe("Scenario 2 — Capability mapping", () => {
     expect(config.disabled_tools).toContain("nx_task_add");
   });
 
-  test("resolveModel: high tier → claude-opus-4 for claude", () => {
+  test("resolveModel: high tier → opus alias for claude", () => {
     const model = resolveModel("high", "claude", capMatrix);
-    expect(model).toBe("claude-opus-4");
+    expect(model).toBe("opus");
   });
 
   test("resolveModel: standard tier → null for opencode (inherit user config)", () => {
@@ -462,6 +463,32 @@ describe("Scenario 2 — Capability mapping", () => {
   test("resolveModel: unknown tier → null", () => {
     const model = resolveModel("unknown_tier", "claude", capMatrix);
     expect(model).toBeNull();
+  });
+
+  test("validateClaudeModel: aliases pass", () => {
+    expect(() => validateClaudeModel("opus", "architect")).not.toThrow();
+    expect(() => validateClaudeModel("sonnet", "engineer")).not.toThrow();
+    expect(() => validateClaudeModel("haiku", "researcher")).not.toThrow();
+  });
+
+  test("validateClaudeModel: dated IDs with minor version pass", () => {
+    expect(() => validateClaudeModel("claude-opus-4-7", "architect")).not.toThrow();
+    expect(() => validateClaudeModel("claude-sonnet-4-6", "engineer")).not.toThrow();
+    expect(() => validateClaudeModel("claude-haiku-4-5-20251001", "writer")).not.toThrow();
+  });
+
+  test("validateClaudeModel: stale IDs without minor version throw", () => {
+    expect(() => validateClaudeModel("claude-opus-4", "architect")).toThrow(/Invalid model/);
+    expect(() => validateClaudeModel("claude-sonnet-4", "engineer")).toThrow(/Invalid model/);
+    expect(() => validateClaudeModel("claude-haiku-4", "writer")).toThrow(/Invalid model/);
+  });
+
+  test("validateClaudeModel: null/undefined pass", () => {
+    expect(() => validateClaudeModel(null, "architect")).not.toThrow();
+  });
+
+  test("validateClaudeModel: arbitrary string throws", () => {
+    expect(() => validateClaudeModel("gpt-5", "architect")).toThrow(/Invalid model/);
   });
 });
 
@@ -505,7 +532,7 @@ describe("Scenario 3 — Manifest file content", () => {
     buildForClaude(assets, capMatrix, invocations, defaultBuildOpts(tmp));
 
     const content = readFileSync(join(tmp, "agents", "sample-architect.md"), "utf-8");
-    expect(content).toContain("model: claude-opus-4");
+    expect(content).toContain("model: opus");
   });
 
   test("Claude: skill SKILL.md is created with description and body", () => {

--- a/scripts/build-agents.ts
+++ b/scripts/build-agents.ts
@@ -360,6 +360,23 @@ export function resolveModel(
   return val === null || val === undefined ? null : val;
 }
 
+const CLAUDE_MODEL_ALIAS_RE = /^(opus|sonnet|haiku)$/;
+const CLAUDE_MODEL_DATED_RE = /^claude-(opus|sonnet|haiku)-\d+-\d+(-\d{8})?$/;
+
+/**
+ * Validate a resolved model value for the claude harness.
+ * Allowed: alias (opus|sonnet|haiku), dated ID (claude-opus-4-7 etc.), or null/undefined.
+ * Throws on any other value.
+ */
+export function validateClaudeModel(model: string | null, role: string): void {
+  if (model === null || model === undefined) return;
+  if (CLAUDE_MODEL_ALIAS_RE.test(model)) return;
+  if (CLAUDE_MODEL_DATED_RE.test(model)) return;
+  throw new Error(
+    `[build-agents] Invalid model value: "${model}" for role "${role}" on harness "claude". Allowed: alias(opus|sonnet|haiku) or dated ID.`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Overwrite policy
 // ---------------------------------------------------------------------------
@@ -460,6 +477,7 @@ function claudeAgentMarkdown(asset: AssetEntry, capMatrix: CapabilityMatrix, inv
   const fm = asset.frontmatter;
   const disallowed = resolveClaudeDisallowedTools(fm.capabilities ?? [], capMatrix);
   const model = resolveModel(fm.model_tier, "claude", capMatrix);
+  validateClaudeModel(model, asset.name);
 
   const fmLines: string[] = ["---"];
   if (fm.description) fmLines.push(`description: ${JSON.stringify(fm.description)}`);

--- a/scripts/build-hooks.ts
+++ b/scripts/build-hooks.ts
@@ -356,6 +356,14 @@ function compileHandlers(plans: PortabilityPlan[], hookIndex: Map<string, HookEn
         lines.push("globalThis.__NEXUS_INLINE_RULE_TARGETS__ = " + ruleTargetsJson + ";");
       }
 
+      if (hook.name === "agent-bootstrap") {
+        const agentsDir = join(ROOT, "assets/agents");
+        const roleNames = readdirSync(agentsDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name);
+        lines.push("globalThis.__NEXUS_INLINE_AGENT_ROLES__ = " + JSON.stringify(roleNames) + ";");
+      }
+
       lines.push(
         `import handler from ${JSON.stringify(hook.handlerPath)};`,
         `import { readFileSync } from "node:fs";`,

--- a/scripts/smoke/smoke-consumer.ts
+++ b/scripts/smoke/smoke-consumer.ts
@@ -1,11 +1,13 @@
 // Issue #46 — prompt-router runtime asset lookup 회귀 감지 (fresh consumer target 모사)
+// Issue #50 — session_id side-channel + tracker lifecycle integration cases
 
 import { execSync, spawn } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { findPackageRoot } from "../../src/shared/package-root.js";
+import { getSessionId, resetByPpidCache } from "../../src/shared/paths.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = findPackageRoot(__dirname);
@@ -18,9 +20,11 @@ function fail(msg: string): never {
 function spawnWithStdin(
   handlerPath: string,
   payload: string,
+  extraEnv?: Record<string, string>,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    const child = spawn("node", [handlerPath], { stdio: ["pipe", "pipe", "pipe"] });
+    const env = extraEnv ? { ...process.env, ...extraEnv } : process.env;
+    const child = spawn("node", [handlerPath], { stdio: ["pipe", "pipe", "pipe"], env });
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
@@ -101,6 +105,167 @@ try {
   }
 
   console.log("[smoke-consumer] PASS — prompt-router emits system-notice for [run] + [rule] tags in fresh consumer target");
+
+  // Case C — session_id side-channel round-trip
+  const sidTmpDir = mkdtempSync(join(tmpdir(), "nexus-smoke-sid-"));
+  const savedTestPpid = process.env["NEXUS_TEST_PPID"];
+  const savedSessionId = process.env["NEXUS_SESSION_ID"];
+  try {
+    process.env["NEXUS_TEST_PPID"] = "999000";
+    delete process.env["NEXUS_SESSION_ID"];
+
+    const sessionInitHandler = join(ROOT, "dist/hooks/session-init.js");
+    if (!existsSync(sessionInitHandler)) {
+      fail(`session-init.js not found at ${sessionInitHandler} — run \`bun run build\` first`);
+    }
+
+    const payloadC = JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: "test-sid-abc",
+      cwd: sidTmpDir,
+      source: "startup",
+    });
+    const resultC = await spawnWithStdin(sessionInitHandler, payloadC, { NEXUS_TEST_PPID: "999000" });
+    if (resultC.code !== 0) {
+      fail(
+        `case C (session-init) exited with code ${resultC.code}\n` +
+        `  stderr: ${resultC.stderr.slice(0, 300)}`,
+      );
+    }
+
+    const byPpidFile = join(sidTmpDir, ".nexus/state/runtime/by-ppid/999000.json");
+    if (!existsSync(byPpidFile)) {
+      fail(`case C: by-ppid file not created at ${byPpidFile}`);
+    }
+    const byPpidData = JSON.parse(readFileSync(byPpidFile, "utf-8")) as { session_id: string };
+    if (byPpidData.session_id !== "test-sid-abc") {
+      fail(`case C: by-ppid file has session_id="${byPpidData.session_id}", expected "test-sid-abc"`);
+    }
+
+    resetByPpidCache();
+    const resolvedSid = getSessionId(sidTmpDir);
+    if (resolvedSid !== "test-sid-abc") {
+      fail(`case C: getSessionId() returned "${resolvedSid}", expected "test-sid-abc"`);
+    }
+
+    console.log("[smoke-consumer] PASS — case C: session_id side-channel round-trip");
+  } finally {
+    if (savedTestPpid === undefined) {
+      delete process.env["NEXUS_TEST_PPID"];
+    } else {
+      process.env["NEXUS_TEST_PPID"] = savedTestPpid;
+    }
+    if (savedSessionId !== undefined) {
+      process.env["NEXUS_SESSION_ID"] = savedSessionId;
+    }
+    rmSync(sidTmpDir, { recursive: true, force: true });
+  }
+
+  // Case D — tracker lifecycle: session-init → agent-bootstrap → agent-finalize
+  const trackerTmpDir = mkdtempSync(join(tmpdir(), "nexus-smoke-tracker-"));
+  const savedTestPpid2 = process.env["NEXUS_TEST_PPID"];
+  const savedSessionId2 = process.env["NEXUS_SESSION_ID"];
+  try {
+    process.env["NEXUS_TEST_PPID"] = "999001";
+    delete process.env["NEXUS_SESSION_ID"];
+
+    const sessionInitHandler = join(ROOT, "dist/hooks/session-init.js");
+    const bootstrapHandler = join(ROOT, "dist/hooks/agent-bootstrap.js");
+    const finalizeHandler = join(ROOT, "dist/hooks/agent-finalize.js");
+
+    for (const h of [sessionInitHandler, bootstrapHandler, finalizeHandler]) {
+      if (!existsSync(h)) {
+        fail(`case D: handler not found at ${h} — run \`bun run build\` first`);
+      }
+    }
+
+    const initPayload = JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: "test-sid-abc",
+      cwd: trackerTmpDir,
+      source: "startup",
+    });
+    const initResult = await spawnWithStdin(sessionInitHandler, initPayload, { NEXUS_TEST_PPID: "999001" });
+    if (initResult.code !== 0) {
+      fail(`case D (session-init) exited with code ${initResult.code}\n  stderr: ${initResult.stderr.slice(0, 300)}`);
+    }
+
+    const trackerPath = join(trackerTmpDir, ".nexus/state/test-sid-abc/agent-tracker.json");
+    if (!existsSync(trackerPath)) {
+      fail(`case D: agent-tracker.json not created at ${trackerPath}`);
+    }
+    const initTracker = JSON.parse(readFileSync(trackerPath, "utf-8"));
+    if (!Array.isArray(initTracker) || initTracker.length !== 0) {
+      fail(`case D: agent-tracker.json after session-init should be [], got ${JSON.stringify(initTracker)}`);
+    }
+
+    const bootstrapPayload = JSON.stringify({
+      hook_event_name: "SubagentStart",
+      cwd: trackerTmpDir,
+      session_id: "test-sid-abc",
+      agent_type: "architect",
+      agent_id: "test-agent-xyz",
+    });
+    const bootstrapResult = await spawnWithStdin(bootstrapHandler, bootstrapPayload, { NEXUS_TEST_PPID: "999001" });
+    if (bootstrapResult.code !== 0) {
+      fail(`case D (agent-bootstrap) exited with code ${bootstrapResult.code}\n  stderr: ${bootstrapResult.stderr.slice(0, 300)}`);
+    }
+
+    const afterBootstrap = JSON.parse(readFileSync(trackerPath, "utf-8")) as Array<Record<string, unknown>>;
+    if (!Array.isArray(afterBootstrap) || afterBootstrap.length !== 1) {
+      fail(`case D: tracker after bootstrap should have 1 entry, got ${JSON.stringify(afterBootstrap)}`);
+    }
+    const entry = afterBootstrap[0]!;
+    if (entry["agent_id"] !== "test-agent-xyz") {
+      fail(`case D: tracker entry agent_id="${entry["agent_id"]}", expected "test-agent-xyz"`);
+    }
+    if (entry["agent_type"] !== "architect") {
+      fail(`case D: tracker entry agent_type="${entry["agent_type"]}", expected "architect"`);
+    }
+    if (entry["status"] !== "running") {
+      fail(`case D: tracker entry status="${entry["status"]}", expected "running"`);
+    }
+    if (typeof entry["started_at"] !== "string" || !entry["started_at"]) {
+      fail(`case D: tracker entry started_at missing or not a string`);
+    }
+
+    const finalizePayload = JSON.stringify({
+      hook_event_name: "SubagentStop",
+      cwd: trackerTmpDir,
+      session_id: "test-sid-abc",
+      agent_type: "architect",
+      agent_id: "test-agent-xyz",
+      last_assistant_message: "",
+    });
+    const finalizeResult = await spawnWithStdin(finalizeHandler, finalizePayload, { NEXUS_TEST_PPID: "999001" });
+    if (finalizeResult.code !== 0) {
+      fail(`case D (agent-finalize) exited with code ${finalizeResult.code}\n  stderr: ${finalizeResult.stderr.slice(0, 300)}`);
+    }
+
+    const afterFinalize = JSON.parse(readFileSync(trackerPath, "utf-8")) as Array<Record<string, unknown>>;
+    if (!Array.isArray(afterFinalize) || afterFinalize.length !== 1) {
+      fail(`case D: tracker after finalize should have 1 entry, got ${JSON.stringify(afterFinalize)}`);
+    }
+    const finalEntry = afterFinalize[0]!;
+    if (finalEntry["status"] !== "completed") {
+      fail(`case D: tracker entry status="${finalEntry["status"]}", expected "completed"`);
+    }
+    if (typeof finalEntry["stopped_at"] !== "string" || !finalEntry["stopped_at"]) {
+      fail(`case D: tracker entry stopped_at missing or not a string`);
+    }
+
+    console.log("[smoke-consumer] PASS — case D: tracker lifecycle (init → bootstrap → finalize)");
+  } finally {
+    if (savedTestPpid2 === undefined) {
+      delete process.env["NEXUS_TEST_PPID"];
+    } else {
+      process.env["NEXUS_TEST_PPID"] = savedTestPpid2;
+    }
+    if (savedSessionId2 !== undefined) {
+      process.env["NEXUS_SESSION_ID"] = savedSessionId2;
+    }
+    rmSync(trackerTmpDir, { recursive: true, force: true });
+  }
 } finally {
   rmSync(tmpDir, { recursive: true, force: true });
 }

--- a/src/shared/paths.test.ts
+++ b/src/shared/paths.test.ts
@@ -12,6 +12,7 @@ import {
   ensureDir,
   getSessionId,
   getSessionRoot,
+  resetByPpidCache,
 } from './paths.ts';
 
 // ---------------------------------------------------------------------------
@@ -187,6 +188,76 @@ describe('getSessionId', () => {
     } finally {
       fs.rmSync(isolated, { recursive: true, force: true });
     }
+  });
+});
+
+describe('getSessionId — by-ppid side-channel', () => {
+  const TEST_PPID = 99999;
+  let tmpDir: string;
+  let prevSid: string | undefined;
+  let prevTestPpid: string | undefined;
+
+  function byPpidFilePath(): string {
+    return path.join(tmpDir, '.nexus/state/runtime/by-ppid', `${TEST_PPID}.json`);
+  }
+
+  function writeByPpidFile(sessionId: string): void {
+    const dir = path.dirname(byPpidFilePath());
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(byPpidFilePath(), JSON.stringify({ session_id: sessionId, updated_at: new Date().toISOString(), cwd: tmpDir }));
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-ppid-'));
+    prevSid = process.env.NEXUS_SESSION_ID;
+    prevTestPpid = process.env.NEXUS_TEST_PPID;
+    delete process.env.NEXUS_SESSION_ID;
+    process.env.NEXUS_TEST_PPID = String(TEST_PPID);
+    resetByPpidCache();
+  });
+
+  afterEach(() => {
+    if (prevSid === undefined) delete process.env.NEXUS_SESSION_ID;
+    else process.env.NEXUS_SESSION_ID = prevSid;
+    if (prevTestPpid === undefined) delete process.env.NEXUS_TEST_PPID;
+    else process.env.NEXUS_TEST_PPID = prevTestPpid;
+    resetByPpidCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('A. NEXUS_SESSION_ID env 최우선 — by-ppid 파일 무관하게 env 값 반환', () => {
+    writeByPpidFile('from-file-session');
+    process.env.NEXUS_SESSION_ID = 'env-wins';
+    expect(getSessionId(tmpDir)).toBe('env-wins');
+  });
+
+  test('B. by-ppid 파일 있을 때 — 파일의 session_id 반환', () => {
+    writeByPpidFile('session-from-ppid-file');
+    expect(getSessionId(tmpDir)).toBe('session-from-ppid-file');
+  });
+
+  test('C. by-ppid 파일 없으면 — branch-pid fallback', () => {
+    const isolated = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-ppid-nogit-'));
+    try {
+      const sid = getSessionId(isolated);
+      expect(sid).toBe(`unknown-${process.pid}`);
+    } finally {
+      fs.rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  test('D. by-ppid 파일 mtime 변경 시 캐시 invalidate — 갱신된 session_id 반환', () => {
+    writeByPpidFile('first-session');
+    expect(getSessionId(tmpDir)).toBe('first-session');
+
+    const before = fs.statSync(byPpidFilePath()).mtimeMs;
+    let after = before;
+    while (after === before) {
+      writeByPpidFile('second-session');
+      after = fs.statSync(byPpidFilePath()).mtimeMs;
+    }
+
+    expect(getSessionId(tmpDir)).toBe('second-session');
   });
 });
 

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, statSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
 
 /**
@@ -66,10 +66,56 @@ function sanitizeBranch(name: string): string {
   return name.replace(/[^a-zA-Z0-9_-]+/g, '_');
 }
 
-/** NEXUS_SESSION_ID env 우선, 없으면 '<branch>-<pid>' 또는 'unknown-<pid>' */
+function runtimeByPpidDir(cwd: string): string {
+  return join(cwd, '.nexus/state/runtime/by-ppid');
+}
+
+function byPpidFilePath(cwd: string, ppid: number): string {
+  return join(runtimeByPpidDir(cwd), `${ppid}.json`);
+}
+
+export function getParentPid(): number {
+  const testOverride = parseInt(process.env['NEXUS_TEST_PPID'] ?? '');
+  return testOverride || process.ppid;
+}
+
+interface ByPpidCache {
+  mtimeMs: number;
+  value: string;
+}
+
+const byPpidCache = new Map<string, ByPpidCache>();
+
+export function resetByPpidCache(): void {
+  byPpidCache.clear();
+}
+
+function readSessionIdFromByPpidFile(cwd: string): string | null {
+  try {
+    const ppid = getParentPid();
+    const filePath = byPpidFilePath(cwd, ppid);
+    const st = statSync(filePath);
+    const cached = byPpidCache.get(filePath);
+    if (cached && cached.mtimeMs === st.mtimeMs) {
+      return cached.value;
+    }
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as { session_id: string };
+    byPpidCache.set(filePath, { mtimeMs: st.mtimeMs, value: parsed.session_id });
+    return parsed.session_id;
+  } catch {
+    return null;
+  }
+}
+
+/** NEXUS_SESSION_ID env 우선, 없으면 by-ppid 파일, 없으면 '<branch>-<pid>' 또는 'unknown-<pid>' */
 export function getSessionId(cwd?: string): string {
   const envId = process.env['NEXUS_SESSION_ID'];
   if (envId) return envId;
+
+  const resolvedCwd = cwd ?? process.cwd();
+  const byPpidId = readSessionIdFromByPpidFile(resolvedCwd);
+  if (byPpidId) return byPpidId;
 
   const branch = getCurrentBranch(cwd);
   const pid = process.pid;


### PR DESCRIPTION
## Summary

v0.16.1 downstream e2e validation ([#50](https://github.com/moreih29/nexus-core/issues/50))에서 발견된 4건 회귀 일괄 수정.

### Bug #1 (P0) — MCP session_id wiring
- MCP server가 자기 session_id를 몰라 `unknown-<pid>` fallback → state 경로 분기 → `[d]`/`[run]` 태그 dispatch 영구 차단
- 3 harness(Claude/OpenCode/Codex) 모두 upstream 공식 session_id 노출 없음을 웹조사로 확인
- **parent-PID keyed side-channel** 채택: `session-init` hook이 `.nexus/state/runtime/by-ppid/<process.ppid>.json` 작성, `paths.ts:getSessionId()`가 `process.ppid` 기반으로 읽음(mtime 캐싱)
- 병렬 harness 세션이 같은 cwd에 있어도 ppid가 다르므로 race-free

### Bug #2 (P1) — agent-bootstrap assets lookup
- `loadValidRoles(cwd)`의 `join(cwd, "assets/agents")` FS lookup이 consumer 설치에서 항상 빈 배열 → 모든 subagent bootstrap skip (#46과 동일 클래스)
- `scripts/build-hooks.ts`의 prompt-router inline 패턴을 `agent-bootstrap` entry에 확장 — `globalThis.__NEXUS_INLINE_AGENT_ROLES__` 빌드타임 주입

### Bug #3 (P1) — agent-tracker populate 주체 부재
- `agent-tracker.json` append 경로 자체가 없어 lifecycle 관측 영구 dead
- `agent-bootstrap` SubagentStart에 idempotent append 추가
- `post-tool-telemetry/meta.yml`의 over-declared `bash_parsed` capability 제거 → Claude/OpenCode 정상 등록 (`tier=extended`)

### Bug #4 (P0) — stale model IDs
- `claude-opus-4` 등은 실제 존재하지 않는 ID → subagent spawn outright 실패
- `capability-matrix.yml` model_tier.*.claude를 alias(`opus`/`sonnet`/`haiku`)로 교체 (version-tolerant)
- `scripts/build-agents.ts:validateClaudeModel()` 빌드타임 gate 추가 — minor 버전 누락 dated ID(`claude-opus-4` 등) build fail

### 재발 방지
- `scripts/smoke/smoke-consumer.ts` integration case 2건 추가:
  - Case C: session_id side-channel round-trip
  - Case D: tracker lifecycle (init → bootstrap → finalize)

## Test plan

- [x] `bun test` — 603 pass, 0 fail (기존 598 + validateClaudeModel 5건)
- [x] `bun run build` — 성공, 타입 에러 없음
- [x] `bun run smoke:claude` — PASS
- [x] `bun run smoke:codex` — PASS (10 file(s) passed standalone schema check)
- [x] `bun run smoke:opencode` — PASS
- [x] `bun run smoke:consumer` — PASS (3/3 케이스)
- [x] Regression gate 실증: `capability-matrix.yml`에 `claude-opus-4` 주입 시 build fail → 원복 정상

## Migration

- consumer 측 추가 작업 없음 — `.nexus/state/runtime/by-ppid/`는 `session-init`이 자동 생성
- `bun add @moreih29/nexus-core@^0.17.0` 후 `nexus sync --harness=<harness>` 권장

Closes #50