### PR TITLE
chore(release): v0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Nexus core reboot workspace. Legacy implementation is archived under .legacy/.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `@moreih29/nexus-core` from `0.19.0` to `0.19.1`
- package the merged fixes for #57, #58, and #59 into a patch release

## Included fixes
- #57 opencode skill frontmatter now emits required `name` and omits unsupported `triggers`
- #58 plan/auto-plan/lead guidance now requires the spawned agent id for resume records
- #59 Codex child-agent specs now preserve the parent nx MCP launcher instead of hardcoding `nexus-mcp`

## Verification
- `bun run validate`
- `npm pack --dry-run`
