### PR TITLE
ci: update release action to node24 line

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,6 +50,6 @@ jobs:
         run: npm publish
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- update the release workflow from `softprops/action-gh-release@v2` to `@v3`

## Why
The publish workflow emitted a GitHub Actions Node 20 deprecation warning during the `v0.19.1` release run. The upstream action now documents `v3` as the Node 24 line, while `v2.6.2` is the last Node 20-compatible line.

## Verification
- `bun run validate`
- parsed `.github/workflows/publish-npm.yml` successfully after the update

## Notes
- This is a workflow maintenance change only.
- No package version bump or npm release is needed.
