### PR TITLE
chore(release): v0.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moreih29/nexus-core",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Nexus core reboot workspace. Legacy implementation is archived under .legacy/.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `@moreih29/nexus-core` from `0.19.1` to `0.19.2`
- package the planning-skill resume-macro clarification from #65 into a patch release

## Included fix
- planning skills now explicitly invoke the resume macro when `nx_plan_resume` returns a resumable agent id, instead of describing resume only in natural language

## Verification
- `bun run validate`
- `npm pack --dry-run`
